### PR TITLE
chore: bootstrap main CI workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.idea
+.vscode
+
+coverage
+playwright-report
+**/test-results
+
+.cache
+*.log
+
+storybook-static
+
+node_modules

--- a/.github/workflows/autoprerelease.yml
+++ b/.github/workflows/autoprerelease.yml
@@ -1,0 +1,41 @@
+name: generate changelog and create pre release
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'package.json'
+      - 'CHANGELOG.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          output-file: 'false'
+          version-file: 'package.json'
+          pre-release: 'true'
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}

--- a/.github/workflows/autoprerelease.yml
+++ b/.github/workflows/autoprerelease.yml
@@ -21,7 +21,21 @@ jobs:
         with:
           ref: 'main'
 
+      - name: Detect release manifest
+        id: manifest
+        run: |
+          if [[ -f package.json ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip prerelease preview
+        if: steps.manifest.outputs.present != 'true'
+        run: echo "Skipping prerelease preview because main does not contain package.json yet."
+
       - name: Conventional Changelog Action
+        if: steps.manifest.outputs.present == 'true'
         id: changelog
         uses: TriPSs/conventional-changelog-action@v3
         with:
@@ -29,13 +43,6 @@ jobs:
           output-file: 'false'
           version-file: 'package.json'
           pre-release: 'true'
-
-      - name: Create Release
-        uses: actions/create-release@v1
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          release_name: ${{ steps.changelog.outputs.tag }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
+          git-push: 'false'
+          skip-commit: 'true'
+          skip-tag: 'true'

--- a/.github/workflows/autoprerelease.yml
+++ b/.github/workflows/autoprerelease.yml
@@ -39,7 +39,7 @@ jobs:
         id: changelog
         uses: TriPSs/conventional-changelog-action@v3
         with:
-          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file: 'false'
           version-file: 'package.json'
           pre-release: 'true'

--- a/.github/workflows/autoprerelease.yml
+++ b/.github/workflows/autoprerelease.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: 'main'
 
       - name: Detect release manifest
         id: manifest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Detect runtime project files
         id: project
         run: |
-          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+          if [[ -f package.json && -f bun.lock ]]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -47,3 +47,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,20 +13,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect runtime project files
+        id: project
+        run: |
+          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip codecov
+        if: steps.project.outputs.present != 'true'
+        run: echo "Skipping codecov because this bootstrap PR does not include the project runtime files yet."
+
       - name: Start docker test environment
+        if: steps.project.outputs.present == 'true'
         run: make start
 
       - name: Run unit tests
+        if: steps.project.outputs.present == 'true'
         run: make test-unit
 
       - name: Export coverage
+        if: steps.project.outputs.present == 'true'
         run: make copy-coverage
 
       - name: Stop docker test environment
-        if: always()
+        if: always() && steps.project.outputs.present == 'true'
         run: make down
 
       - name: Upload coverage to Codecov
+        if: steps.project.outputs.present == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,32 @@
+name: codecov
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start docker test environment
+        run: make start
+
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Export coverage
+        run: make copy-coverage
+
+      - name: Stop docker test environment
+        if: always()
+        run: make down
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -13,25 +13,43 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Detect e2e inputs
+        id: e2e
+        run: |
+          present=false
+          if [[ -f package.json && -f pnpm-lock.yaml && -f playwright.config.ts && -d src/test/e2e ]] && find src/test/e2e -type f -name '*.spec.ts' -print -quit | grep -q .; then
+            present=true
+          fi
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+
+      - name: Skip e2e tests
+        if: steps.e2e.outputs.present != 'true'
+        run: echo "Skipping e2e because this bootstrap PR does not include the Playwright project files yet."
+
       - uses: actions/setup-node@v4
+        if: steps.e2e.outputs.present == 'true'
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Install pnpm
+        if: steps.e2e.outputs.present == 'true'
         run: npm install -g pnpm
 
       - name: Install dependencies
+        if: steps.e2e.outputs.present == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
+        if: steps.e2e.outputs.present == 'true'
         run: make ci-playwright-install
 
       - name: Run Playwright tests
+        if: steps.e2e.outputs.present == 'true'
         run: make ci-test-e2e
 
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.e2e.outputs.present == 'true'
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -27,13 +27,9 @@ jobs:
         if: steps.e2e.outputs.present != 'true'
         run: echo "Skipping e2e because this bootstrap PR does not include the Playwright project files yet."
 
-      - name: Install Bun
-        if: steps.e2e.outputs.present == 'true'
-        uses: oven-sh/setup-bun@v2
-
       - name: Install dependencies
         if: steps.e2e.outputs.present == 'true'
-        run: bun install --frozen-lockfile
+        run: make ci-install
 
       - name: Install Playwright browsers
         if: steps.e2e.outputs.present == 'true'

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -27,14 +27,17 @@ jobs:
         if: steps.e2e.outputs.present != 'true'
         run: echo "Skipping e2e because this bootstrap PR does not include the Playwright project files yet."
 
+      - name: Install pnpm
+        if: steps.e2e.outputs.present == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - uses: actions/setup-node@v4
         if: steps.e2e.outputs.present == 'true'
         with:
           node-version: ${{ vars.NODE_VERSION }}
-
-      - name: Install pnpm
-        if: steps.e2e.outputs.present == 'true'
-        run: npm install -g pnpm
+          cache: 'pnpm'
 
       - name: Install dependencies
         if: steps.e2e.outputs.present == 'true'

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -29,15 +29,15 @@ jobs:
 
       - name: Install dependencies
         if: steps.e2e.outputs.present == 'true'
-        run: make ci-install
+        run: make install
 
       - name: Install Playwright browsers
         if: steps.e2e.outputs.present == 'true'
-        run: make ci-playwright-install
+        run: make playwright-install
 
       - name: Run Playwright tests
         if: steps.e2e.outputs.present == 'true'
-        run: make ci-test-e2e
+        run: make test-e2e
 
       - uses: actions/upload-artifact@v4
         if: always() && steps.e2e.outputs.present == 'true'

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -18,7 +18,7 @@ jobs:
         id: e2e
         run: |
           present=false
-          if [[ -f package.json && -f pnpm-lock.yaml && -f playwright.config.ts && -d src/test/e2e ]] && find src/test/e2e -type f -name '*.spec.ts' -print -quit | grep -q .; then
+          if [[ -f package.json && -f bun.lock && -f playwright.config.ts && -d src/test/e2e ]] && find src/test/e2e -type f -name '*.spec.ts' -print -quit | grep -q .; then
             present=true
           fi
           echo "present=$present" >> "$GITHUB_OUTPUT"
@@ -27,21 +27,13 @@ jobs:
         if: steps.e2e.outputs.present != 'true'
         run: echo "Skipping e2e because this bootstrap PR does not include the Playwright project files yet."
 
-      - name: Install pnpm
+      - name: Install Bun
         if: steps.e2e.outputs.present == 'true'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8
-
-      - uses: actions/setup-node@v4
-        if: steps.e2e.outputs.present == 'true'
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         if: steps.e2e.outputs.present == 'true'
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
         if: steps.e2e.outputs.present == 'true'

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -1,0 +1,38 @@
+name: e2e testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: make ci-playwright-install
+
+      - name: Run Playwright tests
+        run: make ci-test-e2e
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Compress Images
         uses: calibreapp/image-actions@main

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -1,0 +1,23 @@
+name: Image optimization
+
+on:
+  pull_request:
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+
+jobs:
+  build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Compress Images
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Detect memory leak inputs
         id: memlab
         run: |
-          if [[ -f package.json && -f pnpm-lock.yaml && -f src/test/memory-leak/runMemlabTests.js ]]; then
+          if [[ -f package.json && -f bun.lock && -f src/test/memory-leak/runMemlabTests.js ]]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -28,22 +28,13 @@ jobs:
         if: steps.memlab.outputs.present != 'true'
         run: echo "Skipping memory leak tests because this bootstrap PR does not include the app test files yet."
 
-      - name: Install pnpm
+      - name: Install Bun
         if: steps.memlab.outputs.present == 'true'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8
-
-      - name: Set up Node.js
-        if: steps.memlab.outputs.present == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         if: steps.memlab.outputs.present == 'true'
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Run memory leak tests
         if: steps.memlab.outputs.present == 'true'

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -28,15 +28,18 @@ jobs:
         if: steps.memlab.outputs.present != 'true'
         run: echo "Skipping memory leak tests because this bootstrap PR does not include the app test files yet."
 
+      - name: Install pnpm
+        if: steps.memlab.outputs.present == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Set up Node.js
         if: steps.memlab.outputs.present == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
-
-      - name: Install pnpm
-        if: steps.memlab.outputs.present == 'true'
-        run: npm install -g pnpm
+          cache: 'pnpm'
 
       - name: Install dependencies
         if: steps.memlab.outputs.present == 'true'

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -28,13 +28,9 @@ jobs:
         if: steps.memlab.outputs.present != 'true'
         run: echo "Skipping memory leak tests because this bootstrap PR does not include the app test files yet."
 
-      - name: Install Bun
-        if: steps.memlab.outputs.present == 'true'
-        uses: oven-sh/setup-bun@v2
-
       - name: Install dependencies
         if: steps.memlab.outputs.present == 'true'
-        run: bun install --frozen-lockfile
+        run: make ci-install
 
       - name: Run memory leak tests
         if: steps.memlab.outputs.present == 'true'

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -1,0 +1,31 @@
+name: memory leak testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  memory-leak-testing:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run memory leak tests
+        run: make ci-test-memory-leak

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -15,17 +15,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect memory leak inputs
+        id: memlab
+        run: |
+          if [[ -f package.json && -f pnpm-lock.yaml && -f src/test/memory-leak/runMemlabTests.js ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip memory leak tests
+        if: steps.memlab.outputs.present != 'true'
+        run: echo "Skipping memory leak tests because this bootstrap PR does not include the app test files yet."
+
       - name: Set up Node.js
+        if: steps.memlab.outputs.present == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Install pnpm
+        if: steps.memlab.outputs.present == 'true'
         run: npm install -g pnpm
 
       - name: Install dependencies
+        if: steps.memlab.outputs.present == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run memory leak tests
+        if: steps.memlab.outputs.present == 'true'
         run: make ci-test-memory-leak

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Install dependencies
         if: steps.memlab.outputs.present == 'true'
-        run: make ci-install
+        run: make install
 
       - name: Run memory leak tests
         if: steps.memlab.outputs.present == 'true'
-        run: make ci-test-memory-leak
+        run: make test-memory-leak

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Detect runtime project files
         id: project
         run: |
-          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+          if [[ -f package.json && -f bun.lock ]]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,24 @@
+name: Mutation Testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  mutation-testing:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start docker test environment
+        run: make start
+
+      - name: Run mutation testing
+        run: make test-mutation
+
+      - name: Stop docker test environment
+        if: always()
+        run: make down

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -13,12 +13,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect runtime project files
+        id: project
+        run: |
+          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip mutation testing
+        if: steps.project.outputs.present != 'true'
+        run: echo "Skipping mutation testing because this bootstrap PR does not include the project runtime files yet."
+
       - name: Start docker test environment
+        if: steps.project.outputs.present == 'true'
         run: make start
 
       - name: Run mutation testing
+        if: steps.project.outputs.present == 'true'
         run: make test-mutation
 
       - name: Stop docker test environment
-        if: always()
+        if: always() && steps.project.outputs.present == 'true'
         run: make down

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -1,0 +1,45 @@
+name: security testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['typescript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache CodeQL databases
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.workspace }}/codeql_databases
+          key: ${{ runner.os }}-codeql-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-codeql-
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -55,6 +55,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          db-location: ${{ github.workspace }}/codeql_databases
 
       - name: Autobuild
         if: steps.sources.outputs.present == 'true'

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/codeql_databases
-          key: ${{ runner.os }}-codeql-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-codeql-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-codeql-
 

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect TypeScript sources
         id: sources
@@ -43,25 +43,25 @@ jobs:
 
       - name: Cache CodeQL databases
         if: steps.sources.outputs.present == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
-          path: ${{ runner.workspace }}/codeql_databases
+          path: ${{ github.workspace }}/codeql_databases
           key: ${{ runner.os }}-codeql-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-codeql-
 
       - name: Initialize CodeQL
         if: steps.sources.outputs.present == 'true'
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
         if: steps.sources.outputs.present == 'true'
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
         if: steps.sources.outputs.present == 'true'
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -21,9 +21,28 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Detect TypeScript sources
+        id: sources
+        run: |
+          present=false
+          if find . \
+            -path './.git' -prune -o \
+            -path './node_modules' -prune -o \
+            -path './.github' -prune -o \
+            \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+            -print -quit | grep -q .; then
+            present=true
+          fi
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+
+      - name: Skip CodeQL
+        if: steps.sources.outputs.present != 'true'
+        run: echo "Skipping CodeQL because this bootstrap PR does not include JavaScript or TypeScript source files yet."
 
       - name: Cache CodeQL databases
+        if: steps.sources.outputs.present == 'true'
         uses: actions/cache@v3
         with:
           path: ${{ runner.workspace }}/codeql_databases
@@ -32,14 +51,17 @@ jobs:
             ${{ runner.os }}-codeql-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        if: steps.sources.outputs.present == 'true'
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        if: steps.sources.outputs.present == 'true'
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        if: steps.sources.outputs.present == 'true'
+        uses: github/codeql-action/analyze@v3
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Detect runtime project files
         id: project
         run: |
-          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+          if [[ -f package.json && -f bun.lock ]]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -12,21 +12,39 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect runtime project files
+        id: project
+        run: |
+          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip static checks
+        if: steps.project.outputs.present != 'true'
+        run: echo "Skipping static checks because this bootstrap PR does not include the project runtime files yet."
+
       - name: Start docker test environment
+        if: steps.project.outputs.present == 'true'
         run: make start
 
       - name: Run next linter
+        if: steps.project.outputs.present == 'true'
         run: make lint-next
 
       - name: Run tsc linter
+        if: steps.project.outputs.present == 'true'
         run: make lint-tsc
 
       - name: Run markdown linter
+        if: steps.project.outputs.present == 'true'
         run: make lint-md
 
       - name: Run code formatter
+        if: steps.project.outputs.present == 'true'
         run: make format-check
 
       - name: Stop docker test environment
-        if: always()
+        if: always() && steps.project.outputs.present == 'true'
         run: make down

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -1,0 +1,32 @@
+name: static testing
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start docker test environment
+        run: make start
+
+      - name: Run next linter
+        run: make lint-next
+
+      - name: Run tsc linter
+        run: make lint-tsc
+
+      - name: Run markdown linter
+        run: make lint-md
+
+      - name: Run code formatter
+        run: make format-check
+
+      - name: Stop docker test environment
+        if: always()
+        run: make down

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Detect runtime project files
         id: project
         run: |
-          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+          if [[ -f package.json && -f bun.lock ]]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,0 +1,23 @@
+name: unit testing
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start docker test environment
+        run: make start
+
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Stop docker test environment
+        if: always()
+        run: make down

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -12,12 +12,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect runtime project files
+        id: project
+        run: |
+          if [[ -f package.json && -f pnpm-lock.yaml && -f checkNodeVersion.js ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip unit tests
+        if: steps.project.outputs.present != 'true'
+        run: echo "Skipping unit tests because this bootstrap PR does not include the project runtime files yet."
+
       - name: Start docker test environment
+        if: steps.project.outputs.present == 'true'
         run: make start
 
       - name: Run unit tests
+        if: steps.project.outputs.present == 'true'
         run: make test-unit
 
       - name: Stop docker test environment
-        if: always()
+        if: always() && steps.project.outputs.present == 'true'
         run: make down

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -27,13 +27,9 @@ jobs:
         if: steps.visual.outputs.present != 'true'
         run: echo "Skipping visual tests because this bootstrap PR does not include visual test files yet."
 
-      - name: Install Bun
-        if: steps.visual.outputs.present == 'true'
-        uses: oven-sh/setup-bun@v2
-
       - name: Install dependencies
         if: steps.visual.outputs.present == 'true'
-        run: bun install --frozen-lockfile
+        run: make ci-install
 
       - name: Install Playwright Browsers
         if: steps.visual.outputs.present == 'true'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -18,7 +18,7 @@ jobs:
         id: visual
         run: |
           present=false
-          if [[ -f package.json && -f pnpm-lock.yaml && -f playwright.config.ts && -d src/test/visual ]] && find src/test/visual -type f -print -quit | grep -q .; then
+          if [[ -f package.json && -f bun.lock && -f playwright.config.ts && -d src/test/visual ]] && find src/test/visual -type f -print -quit | grep -q .; then
             present=true
           fi
           echo "present=$present" >> "$GITHUB_OUTPUT"
@@ -27,22 +27,13 @@ jobs:
         if: steps.visual.outputs.present != 'true'
         run: echo "Skipping visual tests because this bootstrap PR does not include visual test files yet."
 
-      - name: Install pnpm
+      - name: Install Bun
         if: steps.visual.outputs.present == 'true'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8
-
-      - name: Use Node.js
-        if: steps.visual.outputs.present == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         if: steps.visual.outputs.present == 'true'
-        run: pnpm install --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Install Playwright Browsers
         if: steps.visual.outputs.present == 'true'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -14,26 +14,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect visual test inputs
+        id: visual
+        run: |
+          present=false
+          if [[ -f package.json && -f pnpm-lock.yaml && -f playwright.config.ts && -d src/test/visual ]] && find src/test/visual -type f -print -quit | grep -q .; then
+            present=true
+          fi
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+
+      - name: Skip visual tests
+        if: steps.visual.outputs.present != 'true'
+        run: echo "Skipping visual tests because this bootstrap PR does not include visual test files yet."
+
       - name: Use Node.js
+        if: steps.visual.outputs.present == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: Install pnpm
+        if: steps.visual.outputs.present == 'true'
         run: npm install -g pnpm
 
       - name: Install dependencies
+        if: steps.visual.outputs.present == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Browsers
+        if: steps.visual.outputs.present == 'true'
         run: make ci-playwright-install
 
       - name: Run visual tests
+        if: steps.visual.outputs.present == 'true'
         run: make ci-test-visual
 
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.visual.outputs.present == 'true'
         with:
           name: visual-test-report
           path: playwright-report/

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -27,15 +27,18 @@ jobs:
         if: steps.visual.outputs.present != 'true'
         run: echo "Skipping visual tests because this bootstrap PR does not include visual test files yet."
 
+      - name: Install pnpm
+        if: steps.visual.outputs.present == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Use Node.js
         if: steps.visual.outputs.present == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
-
-      - name: Install pnpm
-        if: steps.visual.outputs.present == 'true'
-        run: npm install -g pnpm
+          cache: 'pnpm'
 
       - name: Install dependencies
         if: steps.visual.outputs.present == 'true'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -29,15 +29,15 @@ jobs:
 
       - name: Install dependencies
         if: steps.visual.outputs.present == 'true'
-        run: make ci-install
+        run: make install
 
       - name: Install Playwright Browsers
         if: steps.visual.outputs.present == 'true'
-        run: make ci-playwright-install
+        run: make playwright-install
 
       - name: Run visual tests
         if: steps.visual.outputs.present == 'true'
-        run: make ci-test-visual
+        run: make test-visual
 
       - uses: actions/upload-artifact@v4
         if: always() && steps.visual.outputs.present == 'true'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -1,0 +1,40 @@
+name: Visual Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  visual-test:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: make ci-playwright-install
+
+      - name: Run visual tests
+        run: make ci-test-visual
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: visual-test-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/yaml-formater.yml
+++ b/.github/workflows/yaml-formater.yml
@@ -1,0 +1,12 @@
+name: Format yaml files
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  yamlfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: norwd/fmtya@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
 FROM node:20-alpine3.17
 
 RUN apk add --no-cache python3 make g++ \
-    && npm install -g pnpm
+    && npm install -g pnpm \
+    && addgroup -S app \
+    && adduser -S -G app app
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml checkNodeVersion.js ./
-
-RUN pnpm install --frozen-lockfile
-
 COPY . .
+
+RUN if [ -f package.json ]; then \
+      if [ -f pnpm-lock.yaml ]; then \
+        pnpm install --frozen-lockfile; \
+      else \
+        pnpm install; \
+      fi; \
+    fi \
+    && chown -R app:app /app
+
+USER app
 
 CMD ["sh", "-lc", "while :; do sleep 3600; done"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine3.17
+
+RUN apk add --no-cache python3 make g++ \
+    && npm install -g pnpm
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml checkNodeVersion.js ./
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+CMD ["sh", "-lc", "while :; do sleep 3600; done"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:20-alpine3.17
 
+ARG PNPM_VERSION=8
+
 RUN apk add --no-cache python3 make g++ \
-    && npm install -g pnpm \
+    && npm install -g pnpm@${PNPM_VERSION} \
     && addgroup -S app \
     && adduser -S -G app app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,13 @@ RUN apk add --no-cache \
     make=4.4.1-r2 \
     python3=3.12.12-r0 \
     && addgroup -S app \
-    && adduser -S -G app app
+    && adduser -S -G app -h /home/app app \
+    && mkdir -p /home/app \
+    && chown app:app /home/app
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+
+ENV HOME=/home/app
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,34 @@
-FROM node:20-alpine3.17
+FROM public.ecr.aws/docker/library/node:24.8.0-alpine3.21
 
-ARG PNPM_VERSION=8
+ARG CURL_VERSION=8.14.1-r2
 
-RUN apk add --no-cache python3 make g++ \
-    && npm install -g pnpm@${PNPM_VERSION} \
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN apk add --no-cache \
+    bash=5.2.37-r0 \
+    curl=${CURL_VERSION} \
+    g++=14.2.0-r4 \
+    make=4.4.1-r2 \
+    python3=3.12.12-r0 \
     && addgroup -S app \
     && adduser -S -G app app
+
+ENV BUN_INSTALL=/home/app/.bun
+ENV PATH="/home/app/.bun/bin:$PATH"
 
 WORKDIR /app
 
 COPY . .
 
-RUN if [ -f package.json ]; then \
-      if [ -f pnpm-lock.yaml ]; then \
-        pnpm install --frozen-lockfile; \
+RUN curl --retry 5 --retry-delay 2 -fsSL https://bun.sh/install | bash -s "bun-v1.3.5" \
+    && if [ -f package.json ]; then \
+      if [ -f bun.lock ]; then \
+        bun install --frozen-lockfile; \
       else \
-        pnpm install; \
+        bun install; \
       fi; \
     fi \
-    && chown -R app:app /app
+    && chown -R app:app /app /home/app/.bun
 
 USER app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,31 @@
-FROM public.ecr.aws/docker/library/node:24.8.0-alpine3.21
+FROM oven/bun:1.3.5@sha256:e90cdbaf9ccdb3d4bd693aa335c3310a6004286a880f62f79b18f9b1312a8ec3 AS bun
 
-ARG CURL_VERSION=8.14.1-r2
+FROM public.ecr.aws/docker/library/node:24.8.0-alpine3.21
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 RUN apk add --no-cache \
     bash=5.2.37-r0 \
-    curl=${CURL_VERSION} \
     g++=14.2.0-r4 \
     make=4.4.1-r2 \
     python3=3.12.12-r0 \
     && addgroup -S app \
     && adduser -S -G app app
 
-ENV BUN_INSTALL=/home/app/.bun
-ENV PATH="/home/app/.bun/bin:$PATH"
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
 WORKDIR /app
 
 COPY . .
 
-RUN curl --retry 5 --retry-delay 2 -fsSL https://bun.sh/install | bash -s "bun-v1.3.5" \
-    && if [ -f package.json ]; then \
+RUN if [ -f package.json ]; then \
       if [ -f bun.lock ]; then \
         bun install --frozen-lockfile; \
       else \
         bun install; \
       fi; \
     fi \
-    && chown -R app:app /app /home/app/.bun
+    && chown -R app:app /app
 
 USER app
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # Parameters
-PROJECT = frontend-ssr-template
 K6 = $(DOCKER) run -v ./src/test/load:/loadTests --net=host --rm k6 run --summary-trend-stats="avg,min,med,max,p(95),p(99)"
 
 # Executables
@@ -23,9 +22,6 @@ BUN_X = $(BUN) x
 	lighthouse-mobile install update ci-install ci-playwright-install ci-test-e2e \
 	ci-test-visual ci-test-memory-leak up down sh ps logs new-logs start stop \
 	build-k6-docker load-tests
-
-# Variables
-REPORT_FILENAME ?= default_value
 
 help:
 	@printf "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m\n"

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,17 @@ PROJECT = frontend-ssr-template
 K6 = $(DOCKER) run -v ./src/test/load:/loadTests --net=host --rm k6 run --summary-trend-stats="avg,min,med,max,p(95),p(99)"
 
 # Executables: local only
-PNPM_BIN = pnpm
+BUN_BIN = bun
 DOCKER = docker
 DOCKER_COMPOSE = docker compose
 
 # Executables
-EXEC_NODEJS = $(DOCKER_COMPOSE) exec -T nodejs
-PNPM = $(EXEC_NODEJS) pnpm
-PNPM_RUN = $(PNPM) run
-HOST_PNPM = pnpm
-HOST_NPX = npx
+EXEC_BUN = $(DOCKER_COMPOSE) exec -T bun
+BUN = $(EXEC_BUN) bun
+BUN_RUN = $(BUN) run
+BUN_X = $(BUN) x
+HOST_BUN = bun
+HOST_BUN_X = bun x
 GIT = git
 
 # Misc
@@ -33,97 +34,97 @@ help:
 	@grep -E '^[-a-zA-Z0-9_\.\/]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-20s\033[0m %s\n", $$1, $$2}'
 
 build: ## Build the project inside the docker container.
-	$(PNPM_RUN) build
+	$(BUN_RUN) build
 
 lint-next: ## Run the Next.js linter inside the docker container.
-	$(PNPM_RUN) lint:next
+	$(BUN_RUN) lint:next
 
 lint-tsc: ## Run the TypeScript linter inside the docker container.
-	$(PNPM_RUN) lint:tsc
+	$(BUN_RUN) lint:tsc
 
 lint-md: ## Run the Markdown linter inside the docker container.
-	$(PNPM_RUN) lint:md
+	$(BUN_RUN) lint:md
 
 format-check: ## Check Prettier formatting inside the docker container.
-	$(PNPM) exec prettier . --check
+	$(BUN_X) prettier . --check
 
 git-hooks-install: ## Install git hooks.
-	$(PNPM_RUN) prepare
+	$(BUN_RUN) prepare
 
 storybook-start: ## Start Storybook inside the docker container.
-	$(PNPM_RUN) storybook-start
+	$(BUN_RUN) storybook-start
 
 storybook-build: ## Build Storybook inside the docker container.
-	$(PNPM_RUN) storybook-build
+	$(BUN_RUN) storybook-build
 
 generate-ts-doc: ## Generate TypeScript documentation inside the docker container.
-	$(PNPM_RUN) generate-ts-doc
+	$(BUN_RUN) generate-ts-doc
 
 test-e2e: ## Run the package e2e script inside the docker container.
-	$(PNPM_RUN) test:e2e
+	$(BUN_RUN) test:e2e
 
 test-e2e-local: ## Open the local Playwright runner inside the docker container.
-	$(PNPM_RUN) test:e2e-local
+	$(BUN_RUN) test:e2e-local
 
 test-unit: ## Run Jest unit tests inside the docker container.
-	$(PNPM_RUN) test:unit
+	$(BUN_RUN) test:unit
 
 copy-coverage: ## Copy the Jest coverage directory from the docker container.
-	$(DOCKER_COMPOSE) cp nodejs:/app/coverage ./coverage
+	$(DOCKER_COMPOSE) cp bun:/app/coverage ./coverage
 
 test-mutation: ## Run mutation tests inside the docker container.
-	$(PNPM_RUN) test:mutation
+	$(BUN_RUN) test:mutation
 
 test-memory-leak: ## Run memory leak tests inside the docker container.
-	$(PNPM_RUN) test:memory-leak
+	$(BUN_RUN) test:memory-leak
 
 lighthouse-desktop: ## Run desktop Lighthouse checks inside the docker container.
-	$(PNPM_RUN) lighthouse:desktop
+	$(BUN_RUN) lighthouse:desktop
 
 lighthouse-mobile: ## Run mobile Lighthouse checks inside the docker container.
-	$(PNPM_RUN) lighthouse:mobile
+	$(BUN_RUN) lighthouse:mobile
 
 install: ## Install dependencies inside the docker container.
-	$(PNPM) install
+	$(BUN) install
 
 update: ## Update dependencies inside the docker container.
-	$(PNPM) update
+	$(BUN) update
 
 ci-playwright-install: ## Install Playwright browsers on the GitHub runner.
-	$(HOST_PNPM) exec playwright install --with-deps
+	$(HOST_BUN_X) playwright install --with-deps
 
 ci-test-e2e: ## Start Storybook on the GitHub runner and run e2e tests.
 	@set -e; \
-	nohup $(HOST_PNPM) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+	nohup $(HOST_BUN) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
 	pid=$$!; \
 	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
-	$(HOST_NPX) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
-	$(HOST_PNPM) exec playwright test ./src/test/e2e
+	$(HOST_BUN_X) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+	$(HOST_BUN_X) playwright test ./src/test/e2e
 
 ci-test-visual: ## Start Storybook on the GitHub runner and run visual tests.
 	@set -e; \
-	nohup $(HOST_PNPM) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+	nohup $(HOST_BUN) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
 	pid=$$!; \
 	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
-	$(HOST_NPX) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
-	$(HOST_PNPM) exec playwright test ./src/test/visual --pass-with-no-tests
+	$(HOST_BUN_X) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+	$(HOST_BUN_X) playwright test ./src/test/visual --pass-with-no-tests
 
 ci-test-memory-leak: ## Start the app on the GitHub runner and run Memlab.
 	@set -e; \
-	nohup $(HOST_PNPM) start >/tmp/ui-toolkit-app.log 2>&1 & \
+	nohup $(HOST_BUN) start >/tmp/ui-toolkit-app.log 2>&1 & \
 	pid=$$!; \
 	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
-	$(HOST_NPX) wait-on --timeout 180000 http://127.0.0.1:3000; \
-	MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 node ./src/test/memory-leak/runMemlabTests.js
+	$(HOST_BUN_X) wait-on --timeout 180000 http://127.0.0.1:3000; \
+	MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 $(HOST_BUN) ./src/test/memory-leak/runMemlabTests.js
 
-up: ## Start the docker hub (Node.js).
+up: ## Start the docker hub (Bun).
 	$(DOCKER_COMPOSE) up -d --build
 
 down: ## Stop the docker hub.
 	$(DOCKER_COMPOSE) down --remove-orphans
 
 sh: ## Open a shell inside the docker container.
-	@$(EXEC_NODEJS) sh
+	@$(EXEC_BUN) sh
 
 ps: ## Show docker compose services.
 	@$(DOCKER_COMPOSE) ps

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ GIT = git
 # Misc
 .DEFAULT_GOAL = help
 .RECIPEPREFIX +=
-.PHONY: $(filter-out node_modules,$(MAKECMDGOALS))
+.PHONY: help build lint-next lint-tsc lint-md format-check git-hooks-install \
+	storybook-start storybook-build generate-ts-doc test-e2e test-e2e-local \
+	test-unit copy-coverage test-mutation test-memory-leak lighthouse-desktop \
+	lighthouse-mobile install update ci-playwright-install ci-test-e2e \
+	ci-test-visual ci-test-memory-leak up down sh ps logs new-logs start stop \
+	build-k6-docker load-tests
 
 # Variables
 REPORT_FILENAME ?= default_value

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Parameters
-K6 = $(DOCKER) run -v ./src/test/load:/loadTests --net=host --rm k6 run --summary-trend-stats="avg,min,med,max,p(95),p(99)"
+K6 = $(DOCKER) run -v ./src/test/load:/loadTests --network ui-toolkit_default --rm k6 run --summary-trend-stats="avg,min,med,max,p(95),p(99)"
 
 # Executables
 DOCKER = docker

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,141 @@
+# Parameters
+PROJECT = frontend-ssr-template
+K6 = $(DOCKER) run -v ./src/test/load:/loadTests --net=host --rm k6 run --summary-trend-stats="avg,min,med,max,p(95),p(99)"
+
+# Executables: local only
+PNPM_BIN = pnpm
+DOCKER = docker
+DOCKER_COMPOSE = docker compose
+
+# Executables
+EXEC_NODEJS = $(DOCKER_COMPOSE) exec -T nodejs
+PNPM = $(EXEC_NODEJS) pnpm
+PNPM_RUN = $(PNPM) run
+HOST_PNPM = pnpm
+HOST_NPX = npx
+GIT = git
+
+# Misc
+.DEFAULT_GOAL = help
+.RECIPEPREFIX +=
+.PHONY: $(filter-out node_modules,$(MAKECMDGOALS))
+
+# Variables
+REPORT_FILENAME ?= default_value
+
+help:
+	@printf "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m\n"
+	@grep -E '^[-a-zA-Z0-9_\.\/]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-20s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the project inside the docker container.
+	$(PNPM_RUN) build
+
+lint-next: ## Run the Next.js linter inside the docker container.
+	$(PNPM_RUN) lint:next
+
+lint-tsc: ## Run the TypeScript linter inside the docker container.
+	$(PNPM_RUN) lint:tsc
+
+lint-md: ## Run the Markdown linter inside the docker container.
+	$(PNPM_RUN) lint:md
+
+format-check: ## Check Prettier formatting inside the docker container.
+	$(PNPM) exec prettier . --check
+
+git-hooks-install: ## Install git hooks.
+	$(PNPM_RUN) prepare
+
+storybook-start: ## Start Storybook inside the docker container.
+	$(PNPM_RUN) storybook-start
+
+storybook-build: ## Build Storybook inside the docker container.
+	$(PNPM_RUN) storybook-build
+
+generate-ts-doc: ## Generate TypeScript documentation inside the docker container.
+	$(PNPM_RUN) generate-ts-doc
+
+test-e2e: ## Run the package e2e script inside the docker container.
+	$(PNPM_RUN) test:e2e
+
+test-e2e-local: ## Open the local Playwright runner inside the docker container.
+	$(PNPM_RUN) test:e2e-local
+
+test-unit: ## Run Jest unit tests inside the docker container.
+	$(PNPM_RUN) test:unit
+
+copy-coverage: ## Copy the Jest coverage directory from the docker container.
+	$(DOCKER_COMPOSE) cp nodejs:/app/coverage ./coverage
+
+test-mutation: ## Run mutation tests inside the docker container.
+	$(PNPM_RUN) test:mutation
+
+test-memory-leak: ## Run memory leak tests inside the docker container.
+	$(PNPM_RUN) test:memory-leak
+
+lighthouse-desktop: ## Run desktop Lighthouse checks inside the docker container.
+	$(PNPM_RUN) lighthouse:desktop
+
+lighthouse-mobile: ## Run mobile Lighthouse checks inside the docker container.
+	$(PNPM_RUN) lighthouse:mobile
+
+install: ## Install dependencies inside the docker container.
+	$(PNPM) install
+
+update: ## Update dependencies inside the docker container.
+	$(PNPM) update
+
+ci-playwright-install: ## Install Playwright browsers on the GitHub runner.
+	$(HOST_PNPM) exec playwright install --with-deps
+
+ci-test-e2e: ## Start Storybook on the GitHub runner and run e2e tests.
+	@set -e; \
+	nohup $(HOST_PNPM) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+	pid=$$!; \
+	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
+	$(HOST_NPX) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+	$(HOST_PNPM) exec playwright test ./src/test/e2e
+
+ci-test-visual: ## Start Storybook on the GitHub runner and run visual tests.
+	@set -e; \
+	nohup $(HOST_PNPM) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+	pid=$$!; \
+	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
+	$(HOST_NPX) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+	$(HOST_PNPM) exec playwright test ./src/test/visual --pass-with-no-tests
+
+ci-test-memory-leak: ## Start the app on the GitHub runner and run Memlab.
+	@set -e; \
+	nohup $(HOST_PNPM) start >/tmp/ui-toolkit-app.log 2>&1 & \
+	pid=$$!; \
+	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
+	$(HOST_NPX) wait-on --timeout 180000 http://127.0.0.1:3000; \
+	MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 node ./src/test/memory-leak/runMemlabTests.js
+
+up: ## Start the docker hub (Node.js).
+	$(DOCKER_COMPOSE) up -d --build
+
+down: ## Stop the docker hub.
+	$(DOCKER_COMPOSE) down --remove-orphans
+
+sh: ## Open a shell inside the docker container.
+	@$(EXEC_NODEJS) sh
+
+ps: ## Show docker compose services.
+	@$(DOCKER_COMPOSE) ps
+
+logs: ## Show all docker compose logs.
+	@$(DOCKER_COMPOSE) logs --follow
+
+new-logs: ## Show live docker compose logs without history.
+	@$(DOCKER_COMPOSE) logs --tail=0 --follow
+
+start: up ## Start docker.
+
+stop: ## Stop docker services.
+	$(DOCKER_COMPOSE) stop
+
+build-k6-docker:
+	$(DOCKER) build -t k6 -f ./src/test/load/Dockerfile .
+
+load-tests: build-k6-docker
+	$(K6) --out 'web-dashboard=period=1s&export=/loadTests/results/homepage.html' /loadTests/homepage.js

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,17 @@
 PROJECT = frontend-ssr-template
 K6 = $(DOCKER) run -v ./src/test/load:/loadTests --net=host --rm k6 run --summary-trend-stats="avg,min,med,max,p(95),p(99)"
 
-# Executables: local only
-BUN_BIN = bun
+# Executables
 DOCKER = docker
 DOCKER_COMPOSE = docker compose
 
-# Executables
+# Docker helpers
+RUN_BUN = $(DOCKER_COMPOSE) run --rm bun
+RUN_BUN_SH = $(DOCKER_COMPOSE) run --rm --entrypoint sh bun -lc
 EXEC_BUN = $(DOCKER_COMPOSE) exec -T bun
-BUN = $(EXEC_BUN) bun
+BUN = $(RUN_BUN) bun
 BUN_RUN = $(BUN) run
 BUN_X = $(BUN) x
-HOST_BUN = bun
-HOST_BUN_X = bun x
-GIT = git
 
 # Misc
 .DEFAULT_GOAL = help
@@ -90,36 +88,41 @@ install: ## Install dependencies inside the docker container.
 update: ## Update dependencies inside the docker container.
 	$(BUN) update
 
-ci-install: ## Install Bun and project dependencies on the CI runner.
-	npm install -g bun
-	bun install --frozen-lockfile
+ci-install: ## Install project dependencies inside a Docker container.
+	$(RUN_BUN) bun install --frozen-lockfile
 
-ci-playwright-install: ## Install Playwright browsers on the GitHub runner.
-	$(HOST_BUN_X) playwright install --with-deps
+ci-playwright-install: ## Install Playwright browsers inside a Docker container.
+	$(RUN_BUN) bun x playwright install --with-deps
 
-ci-test-e2e: ## Start Storybook on the GitHub runner and run e2e tests.
-	@set -e; \
-	nohup $(HOST_BUN) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
-	pid=$$!; \
-	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
-	$(HOST_BUN_X) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
-	$(HOST_BUN_X) playwright test ./src/test/e2e
+ci-test-e2e: ## Start Storybook and run e2e tests inside a Docker container.
+	@$(RUN_BUN_SH) '\
+		set -e; \
+		bun run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+		pid=$$!; \
+		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
+		bun x wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+		bun x playwright test ./src/test/e2e \
+	'
 
-ci-test-visual: ## Start Storybook on the GitHub runner and run visual tests.
-	@set -e; \
-	nohup $(HOST_BUN) run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
-	pid=$$!; \
-	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
-	$(HOST_BUN_X) wait-on --timeout 120000 tcp:127.0.0.1:6006; \
-	$(HOST_BUN_X) playwright test ./src/test/visual --pass-with-no-tests
+ci-test-visual: ## Start Storybook and run visual tests inside a Docker container.
+	@$(RUN_BUN_SH) '\
+		set -e; \
+		bun run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+		pid=$$!; \
+		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
+		bun x wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+		bun x playwright test ./src/test/visual --pass-with-no-tests \
+	'
 
-ci-test-memory-leak: ## Start the app on the GitHub runner and run Memlab.
-	@set -e; \
-	nohup $(HOST_BUN) start >/tmp/ui-toolkit-app.log 2>&1 & \
-	pid=$$!; \
-	trap 'kill $$pid >/dev/null 2>&1 || true' EXIT; \
-	$(HOST_BUN_X) wait-on --timeout 180000 http://127.0.0.1:3000; \
-	MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 $(HOST_BUN) ./src/test/memory-leak/runMemlabTests.js
+ci-test-memory-leak: ## Start the app and run Memlab inside a Docker container.
+	@$(RUN_BUN_SH) '\
+		set -e; \
+		bun start >/tmp/ui-toolkit-app.log 2>&1 & \
+		pid=$$!; \
+		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
+		bun x wait-on --timeout 180000 http://127.0.0.1:3000; \
+		MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 bun ./src/test/memory-leak/runMemlabTests.js \
+	'
 
 up: ## Start the docker hub (Bun).
 	$(DOCKER_COMPOSE) up -d --build
@@ -128,7 +131,7 @@ down: ## Stop the docker hub.
 	$(DOCKER_COMPOSE) down --remove-orphans
 
 sh: ## Open a shell inside the docker container.
-	@$(EXEC_BUN) sh
+	@$(DOCKER_COMPOSE) run --rm --entrypoint sh bun
 
 ps: ## Show docker compose services.
 	@$(DOCKER_COMPOSE) ps

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,9 @@ BUN_X = $(BUN) x
 .RECIPEPREFIX +=
 .PHONY: help build lint-next lint-tsc lint-md format-check git-hooks-install \
 	storybook-start storybook-build generate-ts-doc test-e2e test-e2e-local \
-	test-unit copy-coverage test-mutation test-memory-leak lighthouse-desktop \
-	lighthouse-mobile install update ci-install ci-playwright-install ci-test-e2e \
-	ci-test-visual ci-test-memory-leak up down sh ps logs new-logs start stop \
-	build-k6-docker load-tests
+	test-unit copy-coverage test-mutation test-memory-leak test-visual \
+	lighthouse-desktop lighthouse-mobile install update playwright-install \
+	up down sh ps logs new-logs start stop build-k6-docker load-tests
 
 help:
 	@printf "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m\n"
@@ -54,8 +53,15 @@ storybook-build: ## Build Storybook inside the docker container.
 generate-ts-doc: ## Generate TypeScript documentation inside the docker container.
 	$(BUN_RUN) generate-ts-doc
 
-test-e2e: ## Run the package e2e script inside the docker container.
-	$(BUN_RUN) test:e2e
+test-e2e: ## Start Storybook and run e2e tests inside a Docker container.
+	@$(RUN_BUN_SH) '\
+		set -e; \
+		bun run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
+		pid=$$!; \
+		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
+		bun x wait-on --timeout 120000 tcp:127.0.0.1:6006; \
+		bun x playwright test ./src/test/e2e \
+	'
 
 test-e2e-local: ## Open the local Playwright runner inside the docker container.
 	$(BUN_RUN) test:e2e-local
@@ -69,8 +75,15 @@ copy-coverage: ## Copy the Jest coverage directory from the docker container.
 test-mutation: ## Run mutation tests inside the docker container.
 	$(BUN_RUN) test:mutation
 
-test-memory-leak: ## Run memory leak tests inside the docker container.
-	$(BUN_RUN) test:memory-leak
+test-memory-leak: ## Start the app and run Memlab inside a Docker container.
+	@$(RUN_BUN_SH) '\
+		set -e; \
+		bun start >/tmp/ui-toolkit-app.log 2>&1 & \
+		pid=$$!; \
+		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
+		bun x wait-on --timeout 180000 http://127.0.0.1:3000; \
+		MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 bun ./src/test/memory-leak/runMemlabTests.js \
+	'
 
 lighthouse-desktop: ## Run desktop Lighthouse checks inside the docker container.
 	$(BUN_RUN) lighthouse:desktop
@@ -79,28 +92,15 @@ lighthouse-mobile: ## Run mobile Lighthouse checks inside the docker container.
 	$(BUN_RUN) lighthouse:mobile
 
 install: ## Install dependencies inside the docker container.
-	$(BUN) install
+	$(RUN_BUN) bun install --frozen-lockfile
 
 update: ## Update dependencies inside the docker container.
 	$(BUN) update
 
-ci-install: ## Install project dependencies inside a Docker container.
-	$(RUN_BUN) bun install --frozen-lockfile
-
-ci-playwright-install: ## Install Playwright browsers inside a Docker container.
+playwright-install: ## Install Playwright browsers inside a Docker container.
 	$(RUN_BUN) bun x playwright install --with-deps
 
-ci-test-e2e: ## Start Storybook and run e2e tests inside a Docker container.
-	@$(RUN_BUN_SH) '\
-		set -e; \
-		bun run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
-		pid=$$!; \
-		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
-		bun x wait-on --timeout 120000 tcp:127.0.0.1:6006; \
-		bun x playwright test ./src/test/e2e \
-	'
-
-ci-test-visual: ## Start Storybook and run visual tests inside a Docker container.
+test-visual: ## Start Storybook and run visual tests inside a Docker container.
 	@$(RUN_BUN_SH) '\
 		set -e; \
 		bun run storybook-start >/tmp/ui-toolkit-storybook.log 2>&1 & \
@@ -108,16 +108,6 @@ ci-test-visual: ## Start Storybook and run visual tests inside a Docker containe
 		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
 		bun x wait-on --timeout 120000 tcp:127.0.0.1:6006; \
 		bun x playwright test ./src/test/visual --pass-with-no-tests \
-	'
-
-ci-test-memory-leak: ## Start the app and run Memlab inside a Docker container.
-	@$(RUN_BUN_SH) '\
-		set -e; \
-		bun start >/tmp/ui-toolkit-app.log 2>&1 & \
-		pid=$$!; \
-		trap "kill $$pid >/dev/null 2>&1 || true" EXIT; \
-		bun x wait-on --timeout 180000 http://127.0.0.1:3000; \
-		MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 bun ./src/test/memory-leak/runMemlabTests.js \
 	'
 
 up: ## Start the docker hub (Bun).

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GIT = git
 .PHONY: help build lint-next lint-tsc lint-md format-check git-hooks-install \
 	storybook-start storybook-build generate-ts-doc test-e2e test-e2e-local \
 	test-unit copy-coverage test-mutation test-memory-leak lighthouse-desktop \
-	lighthouse-mobile install update ci-playwright-install ci-test-e2e \
+	lighthouse-mobile install update ci-install ci-playwright-install ci-test-e2e \
 	ci-test-visual ci-test-memory-leak up down sh ps logs new-logs start stop \
 	build-k6-docker load-tests
 
@@ -89,6 +89,10 @@ install: ## Install dependencies inside the docker container.
 
 update: ## Update dependencies inside the docker container.
 	$(BUN) update
+
+ci-install: ## Install Bun and project dependencies on the CI runner.
+	npm install -g bun
+	bun install --frozen-lockfile
 
 ci-playwright-install: ## Install Playwright browsers on the GitHub runner.
 	$(HOST_BUN_X) playwright install --with-deps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,5 @@ services:
   bun:
     build: .
     restart: unless-stopped
+    ports:
+      - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   nodejs:
     build: .
-    command: ['sh', '-lc', 'while :; do sleep 3600; done']
     restart: unless-stopped
     ports:
       - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,3 @@ services:
   bun:
     build: .
     restart: unless-stopped
-    ports:
-      - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 services:
-  nodejs:
+  bun:
     build: .
     restart: unless-stopped
-    ports:
-      - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   nodejs:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  nodejs:
+    build: .
+    command: ['sh', '-lc', 'while :; do sleep 3600; done']
+    restart: unless-stopped
+    ports:
+      - '3000:3000'


### PR DESCRIPTION
## Summary
- add the GitHub Actions workflow set to `main`, including `autoprerelease`
- add a minimal Docker/Make support layer so the project runtime checks can call `make` targets
- rewire the unit, static, codecov, mutation, e2e, visual, and memory-leak workflows around that support layer

## Test Plan
- `git diff --cached --check` before commit
- parsed every workflow YAML successfully with `python3` + `yaml.safe_load`
- app-level workflow execution not run locally because this bootstrap branch intentionally adds only CI/support files, not the project sources

Closes #35