### PR TITLE
ci: enforce Alpine base images with a regression guard (#40)

### DIFF
--- a/.github/workflows/alpine-base-guard.yml
+++ b/.github/workflows/alpine-base-guard.yml
@@ -1,0 +1,54 @@
+name: alpine base guard
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - Dockerfile.*
+      - '**/Dockerfile'
+      - '**/Dockerfile.*'
+      - '*.Dockerfile'
+      - '**/*.Dockerfile'
+      - Containerfile
+      - Containerfile.*
+      - '**/Containerfile'
+      - '**/Containerfile.*'
+      - scripts/ci/alpine_base_guard.sh
+      - .github/workflows/alpine-base-guard.yml
+
+permissions: {}
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      # Tamper-evidence: prove the guard actually trips on a non-Alpine base (and
+      # passes a compliant one) using fixtures outside the repo. A PR that guts the
+      # script to neuter the real check fails here instead of passing vacuously.
+      - name: Guard self-test
+        run: |
+          tmp="$(mktemp -d)"
+          printf 'FROM ubuntu:22.04\n' > "$tmp/Dockerfile.selftest"
+          if bash scripts/ci/alpine_base_guard.sh scan "$tmp/Dockerfile.selftest"; then
+            echo "::error::guard self-test failed: a non-Alpine base did not trip the gate"
+            exit 1
+          fi
+          printf 'FROM alpine:3.19\n' > "$tmp/Dockerfile.ok"
+          bash scripts/ci/alpine_base_guard.sh scan "$tmp/Dockerfile.ok"
+          echo "guard self-test passed"
+
+      - name: Enforce Alpine base images
+        run: bash scripts/ci/alpine_base_guard.sh scan
+        env:
+          ALPINE_EXCEPTION_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'docker-alpine-exception') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,31 @@ When you add or change a public Make target:
 - add or update Bats coverage for uncovered shell flows, or record the PR workflow that already
   exercises the target end to end
 
+### Docker base-image policy (Alpine)
+
+Every Dockerfile must use an Alpine-based image wherever an Alpine variant exists, for a
+smaller image and reduced attack surface.
+
+This is enforced by `scripts/ci/alpine_base_guard.sh scan`, run by the `alpine base guard`
+workflow on PRs to `main`. Run it locally before pushing:
+
+```bash
+bash scripts/ci/alpine_base_guard.sh scan
+```
+
+The guard checks every `Dockerfile`, `Dockerfile.<suffix>`, `<prefix>.Dockerfile`, and
+`Containerfile` in the repo. A base counts as Alpine when its tag or final repository segment
+says so (e.g. `oven/bun:1.3.14-alpine`, `alpine:3.19`); an Alpine-based image that does not
+advertise this in its name (e.g. `alpine/git`) still needs an exception.
+
+Exceptions (default-deny): when no Alpine variant is usable, add an inline
+`# alpine-exception: <reason>` comment to the Dockerfile (a reason is required), or apply the
+`docker-alpine-exception` PR label for emergencies. The marker is file-scoped — one marker
+waives every non-Alpine base in that file — so scrutinise multi-stage Dockerfiles carrying one.
+
+Current documented exception: `Dockerfile.playwright` — the official Playwright browser base
+is glibc-only, with no Alpine/musl variant published.
+
 ### Commit your update
 
 Commit the changes once you are happy with them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,13 @@ When you add or change a public Make target:
 - add or update Bats coverage for uncovered shell flows, or record the PR workflow that already
   exercises the target end to end
 
+### Commit your update
+
+Commit the changes once you are happy with them.
+Don't forget to self-review to speed up the review process :zap:.
+
+Our commits are based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
 ### Docker base-image policy (Alpine)
 
 Every Dockerfile must use an Alpine-based image wherever an Alpine variant exists, for a
@@ -91,13 +98,6 @@ waives every non-Alpine base in that file — so scrutinise multi-stage Dockerfi
 
 Current documented exception: `Dockerfile.playwright` — the official Playwright browser base
 is glibc-only, with no Alpine/musl variant published.
-
-### Commit your update
-
-Commit the changes once you are happy with them.
-Don't forget to self-review to speed up the review process :zap:.
-
-Our commits are based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ### Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,11 @@ workflow on PRs to `main`. Run it locally before pushing:
 bash scripts/ci/alpine_base_guard.sh scan
 ```
 
-The guard checks every `Dockerfile`, `Dockerfile.<suffix>`, `<prefix>.Dockerfile`, and
-`Containerfile` in the repo. A base counts as Alpine when its tag or final repository segment
-says so (e.g. `oven/bun:1.3.14-alpine`, `alpine:3.19`); an Alpine-based image that does not
-advertise this in its name (e.g. `alpine/git`) still needs an exception.
+The guard checks every `Dockerfile`, `Dockerfile.<suffix>`, `<prefix>.Dockerfile`,
+`Containerfile`, and `Containerfile.<suffix>` in the repo. A base counts as Alpine when its tag
+or final repository segment says so (e.g. `oven/bun:1.3.14-alpine`, `alpine:3.19`); an
+Alpine-based image that does not advertise this in its name (e.g. `alpine/git`) still needs an
+exception.
 
 Exceptions (default-deny): when no Alpine variant is usable, add an inline
 `# alpine-exception: <reason>` comment to the Dockerfile (a reason is required), or apply the

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/playwright:v1.59.1-jammy
+# alpine-exception: Playwright's official browser image is Debian (jammy); Chromium/Firefox/WebKit and their system libraries require glibc, and Microsoft publishes no Alpine/musl Playwright base.
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/scripts/ci/alpine_base_guard.sh
+++ b/scripts/ci/alpine_base_guard.sh
@@ -16,6 +16,14 @@ log() {
   printf '%s\n' "$*" >&2
 }
 
+# This guard relies on Bash 4+ features (`${var,,}` lowercasing, name-indexed
+# loops). Fail fast with a clear message instead of cryptic syntax errors on
+# stale shells (e.g. the Bash 3.2 that ships with macOS).
+if (( BASH_VERSINFO[0] < 4 )); then
+  log "alpine base guard: requires bash >= 4 (found ${BASH_VERSION:-unknown})"
+  exit 2
+fi
+
 # classify <image_ref> -> alpine | scratch | non-alpine | unknown
 classify() {
   local ref="${1:-}"
@@ -48,8 +56,12 @@ classify() {
     tag="${last##*:}"
   fi
 
-  # 5. Tag contains `alpine`.
-  if [[ "${tag,,}" == *alpine* ]]; then
+  # 5. Tag marks an Alpine variant. Match `alpine` only on a token boundary:
+  #    exactly `alpine` (e.g. nginx:alpine), a `-alpine` suffix (node:20-alpine),
+  #    or `alpine` immediately followed by its version (20-alpine3.19, alpine3.19).
+  #    A bare substring match is deliberately avoided so a non-Alpine repo with a
+  #    spoof tag such as `notalpine`, `alpine-ish`, or `8.0-alpinexx` cannot pass.
+  if [[ "${tag,,}" =~ (^|-)alpine([0-9]|$) ]]; then
     printf '%s\n' "alpine"
     return 0
   fi
@@ -88,6 +100,18 @@ parse_froms() {
     local rest="${line#"${BASH_REMATCH[0]}"}"
     local -a tokens=()
     read -r -a tokens <<<"$rest"
+
+    # Drop everything from the first inline-comment token onward. A `#` only
+    # ever starts a comment here (image refs never contain one), so this stops
+    # a crafted comment from spoofing the image ref or an `AS <stage>` alias and
+    # sneaking a later `FROM <stage>` past the non-Alpine guard.
+    local -a real_tokens=()
+    local t
+    for t in "${tokens[@]+"${tokens[@]}"}"; do
+      [[ "$t" == '#'* ]] && break
+      real_tokens+=("$t")
+    done
+    tokens=("${real_tokens[@]+"${real_tokens[@]}"}")
 
     # First non-flag token is the image ref.
     local ref=""
@@ -221,10 +245,11 @@ scan() {
   local rc=0
   local file
   for file in "${files[@]+"${files[@]}"}"; do
-    # Fail closed: an explicitly-listed path that does not exist (a deleted,
-    # renamed, or typo'd Dockerfile in a changed-files list) must not pass the
-    # gate by default.
-    if [ ! -f "$file" ]; then
+    # Fail closed: an explicitly-listed path that is missing (a deleted,
+    # renamed, or typo'd Dockerfile in a changed-files list) or exists but is
+    # unreadable must not pass the gate. An unreadable file would otherwise
+    # yield no FROM refs and slip through as a false PASS.
+    if [[ ! -f "$file" || ! -r "$file" ]]; then
       printf '%s | %s | %s\n' "$file" "(missing)" "FAIL: Dockerfile not found or unreadable"
       rc=1
       continue
@@ -233,7 +258,7 @@ scan() {
     local -a refs=()
     local r
     while IFS= read -r r; do
-      [ -n "$r" ] && refs+=("$r")
+      [[ -n "$r" ]] && refs+=("$r")
     done < <(parse_froms "$file")
 
     local file_class="alpine"

--- a/scripts/ci/alpine_base_guard.sh
+++ b/scripts/ci/alpine_base_guard.sh
@@ -56,12 +56,13 @@ classify() {
     tag="${last##*:}"
   fi
 
-  # 5. Tag marks an Alpine variant. Match `alpine` only on a token boundary:
-  #    exactly `alpine` (e.g. nginx:alpine), a `-alpine` suffix (node:20-alpine),
-  #    or `alpine` immediately followed by its version (20-alpine3.19, alpine3.19).
-  #    A bare substring match is deliberately avoided so a non-Alpine repo with a
-  #    spoof tag such as `notalpine`, `alpine-ish`, or `8.0-alpinexx` cannot pass.
-  if [[ "${tag,,}" =~ (^|-)alpine([0-9]|$) ]]; then
+  # 5. Tag marks an Alpine variant. Match `alpine` only as a whole trailing
+  #    token: exactly `alpine` (e.g. nginx:alpine), a `-alpine` suffix
+  #    (node:20-alpine), or `alpine` followed by a numeric version that runs to
+  #    the end of the tag (20-alpine3.19, alpine3.19). Anchoring to `$` rejects
+  #    both substring spoofs (`notalpine`, `alpine-ish`, `8.0-alpinexx`) and
+  #    trailing-junk spoofs (`1.0-alpine9evil`, `alpine3.19-backdoor`).
+  if [[ "${tag,,}" =~ (^|-)alpine([0-9]+([.][0-9]+)*)?$ ]]; then
     printf '%s\n' "alpine"
     return 0
   fi

--- a/scripts/ci/alpine_base_guard.sh
+++ b/scripts/ci/alpine_base_guard.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# Alpine base-image regression guard (issue #40).
+#
+# Hermetic static check: parses Dockerfile FROM lines and fails when a base
+# image is non-Alpine and no documented exception applies. Never touches the
+# network or Docker. Default-deny: any non-Alpine base must carry an inline
+# `# alpine-exception: <reason>` marker (mirrors the `# perf-exception:`
+# convention) or the `docker-alpine-exception` PR label.
+#
+# Exit codes: 0 ok / 1 gate failed / 2 usage error.
+
+set -euo pipefail
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+# classify <image_ref> -> alpine | scratch | non-alpine | unknown
+classify() {
+  local ref="${1:-}"
+
+  # 1. Strip any @sha256:... digest suffix.
+  ref="${ref%%@*}"
+
+  # Empty/garbage ref -> unknown. Unreachable from scan (refs are filtered
+  # before classify), but keeps the standalone subcommand from hard-failing the
+  # gate on a malformed input.
+  [ -n "$ref" ] || { printf '%s\n' "unknown"; return 0; }
+
+  # 2. Exactly `scratch`.
+  local lower="${ref,,}"
+  if [ "$lower" = "scratch" ]; then
+    printf '%s\n' "scratch"
+    return 0
+  fi
+
+  # 3. Unresolved variable.
+  if [[ "$ref" == *'$'* ]]; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
+
+  # 4. Determine the tag from the last path segment (ignores registry:port/).
+  local last="${ref##*/}"
+  local tag=""
+  if [[ "$last" == *:* ]]; then
+    tag="${last##*:}"
+  fi
+
+  # 5. Tag contains `alpine`.
+  if [[ "${tag,,}" == *alpine* ]]; then
+    printf '%s\n' "alpine"
+    return 0
+  fi
+
+  # 6. Repository name (ref with any :tag removed); last segment exactly `alpine`.
+  local repo="$ref"
+  if [[ "$last" == *:* ]]; then
+    repo="${ref%:*}"
+  fi
+  local repo_last="${repo##*/}"
+  if [ "${repo_last,,}" = "alpine" ]; then
+    printf '%s\n' "alpine"
+    return 0
+  fi
+
+  # 7. Otherwise.
+  printf '%s\n' "non-alpine"
+}
+
+# parse-froms <dockerfile> -> external base refs, one per line
+parse_froms() {
+  local file="${1:-}"
+  [ -n "$file" ] && [ -f "$file" ] || return 0
+
+  local -a stages=()
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+
+    # Match: leading space, FROM (case-insensitive), at least one space.
+    if [[ ! "$line" =~ ^[[:space:]]*[Ff][Rr][Oo][Mm][[:space:]]+ ]]; then
+      continue
+    fi
+
+    # Tokenize the remainder after FROM.
+    local rest="${line#"${BASH_REMATCH[0]}"}"
+    local -a tokens=()
+    read -r -a tokens <<<"$rest"
+
+    # First non-flag token is the image ref.
+    local ref=""
+    local tok
+    for tok in "${tokens[@]+"${tokens[@]}"}"; do
+      if [[ "$tok" == --* ]]; then
+        continue
+      fi
+      ref="$tok"
+      break
+    done
+    [ -n "$ref" ] || continue
+
+    # Record AS <name> (case-insensitive) as a known stage.
+    local stage_name=""
+    local i
+    for ((i = 0; i < ${#tokens[@]}; i++)); do
+      if [[ "${tokens[i],,}" == "as" ]] && [ $((i + 1)) -lt ${#tokens[@]} ]; then
+        stage_name="${tokens[i + 1],,}"
+        break
+      fi
+    done
+
+    # Local stage reference -> skip.
+    local is_stage_ref=0
+    local s
+    for s in "${stages[@]+"${stages[@]}"}"; do
+      if [ "${ref,,}" = "$s" ]; then
+        is_stage_ref=1
+        break
+      fi
+    done
+
+    if [ -n "$stage_name" ]; then
+      stages+=("$stage_name")
+    fi
+
+    if [ "$is_stage_ref" -eq 0 ]; then
+      printf '%s\n' "$ref"
+    fi
+  done <"$file"
+}
+
+# detect-exception <dockerfile> -> reason or empty
+#
+# The waiver is file-scoped: a single marker anywhere in the file waives every
+# non-Alpine base it declares. Reviewers should therefore scrutinise any
+# multi-stage Dockerfile that carries a marker (see CONTRIBUTING.md).
+detect_exception() {
+  local file="${1:-}"
+  local line reason
+
+  if [ -n "$file" ] && [ -f "$file" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%$'\r'}"
+      if [[ "$line" =~ ^[[:space:]]*#[[:space:]]*[Aa][Ll][Pp][Ii][Nn][Ee]-[Ee][Xx][Cc][Ee][Pp][Tt][Ii][Oo][Nn][[:space:]]*:[[:space:]]*([^[:space:]].*)$ ]]; then
+        reason="${BASH_REMATCH[1]}"
+        reason="${reason%"${reason##*[![:space:]]}"}"
+        printf '%s\n' "$reason"
+        return 0
+      fi
+    done <"$file"
+  fi
+
+  if [ "${ALPINE_EXCEPTION_LABEL:-}" = "true" ]; then
+    printf '%s\n' "PR label 'docker-alpine-exception' applied"
+    return 0
+  fi
+}
+
+# evaluate -> PASS/EXCEPTION (exit 0) | FAIL (exit 1), driven by env.
+evaluate() {
+  local base_class="${BASE_CLASS:-}"
+  local reason="${EXCEPTION_REASON:-}"
+  local offending="${OFFENDING_REF:-}"
+
+  if [ "$base_class" = "alpine" ] || [ "$base_class" = "scratch" ]; then
+    printf '%s\n' "PASS: base image is Alpine-compliant"
+    return 0
+  fi
+
+  if [ -n "$reason" ]; then
+    printf '%s\n' "EXCEPTION: non-Alpine base waived by documented exception: ${reason}"
+    return 0
+  fi
+
+  if [ -n "$offending" ]; then
+    printf '%s\n' "FAIL: non-Alpine base image; migrate to an Alpine variant or document an exception (offending base: ${offending})"
+  else
+    printf '%s\n' "FAIL: non-Alpine base image; migrate to an Alpine variant or document an exception"
+  fi
+  return 1
+}
+
+# Recognised container-build filenames: `Dockerfile`, `Dockerfile.<suffix>`,
+# `<prefix>.Dockerfile`, and `Containerfile[.<suffix>]`. Kept in sync with the
+# workflow `paths:` trigger so the discovery surface matches the trigger surface.
+readonly DOCKERFILE_BASENAME_RE='^(Dockerfile([.][^/]+)?|[^/]+[.]Dockerfile|Containerfile([.][^/]+)?)$'
+
+# discover_dockerfiles -> list of Dockerfile paths
+discover_dockerfiles() {
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git ls-files | while IFS= read -r path; do
+      local base="${path##*/}"
+      if [[ "$base" =~ $DOCKERFILE_BASENAME_RE ]]; then
+        printf '%s\n' "$path"
+      fi
+    done
+  else
+    # `base` is path-anchored (not `-name base`) so a directory legitimately
+    # named `base/` at any depth is not silently pruned.
+    find . \
+      \( -name node_modules -o -name .git -o -name .stryker-tmp -o -path ./base \) -prune \
+      -o -type f \( -name 'Dockerfile' -o -name 'Dockerfile.*' \
+        -o -name '*.Dockerfile' -o -name 'Containerfile' -o -name 'Containerfile.*' \) -print
+  fi
+}
+
+# scan [dockerfile...] -> exit 0 all-clear / 1 any unwaived violation
+scan() {
+  local -a files=()
+  if [ "$#" -gt 0 ]; then
+    files=("$@")
+  else
+    local f
+    while IFS= read -r f; do
+      [ -n "$f" ] && files+=("$f")
+    done < <(discover_dockerfiles)
+  fi
+
+  local rc=0
+  local file
+  for file in "${files[@]+"${files[@]}"}"; do
+    # Fail closed: an explicitly-listed path that does not exist (a deleted,
+    # renamed, or typo'd Dockerfile in a changed-files list) must not pass the
+    # gate by default.
+    if [ ! -f "$file" ]; then
+      printf '%s | %s | %s\n' "$file" "(missing)" "FAIL: Dockerfile not found or unreadable"
+      rc=1
+      continue
+    fi
+
+    local -a refs=()
+    local r
+    while IFS= read -r r; do
+      [ -n "$r" ] && refs+=("$r")
+    done < <(parse_froms "$file")
+
+    local file_class="alpine"
+    local offending=""
+    local display="(none)"
+    if [ "${#refs[@]}" -gt 0 ]; then
+      display=""
+      local ref class
+      for ref in "${refs[@]}"; do
+        class="$(classify "$ref")"
+        if [ -n "$display" ]; then
+          display+=", "
+        fi
+        display+="$ref"
+        if [ "$class" != "alpine" ] && [ "$class" != "scratch" ] && [ "$file_class" != "non-alpine" ]; then
+          file_class="non-alpine"
+          offending="$ref"
+        fi
+      done
+    fi
+
+    local reason
+    reason="$(detect_exception "$file")"
+
+    local verdict
+    if verdict="$(
+      BASE_CLASS="$file_class" \
+      EXCEPTION_REASON="$reason" \
+      OFFENDING_REF="$offending" \
+      evaluate
+    )"; then
+      :
+    else
+      rc=1
+    fi
+
+    printf '%s | %s | %s\n' "$file" "$display" "$verdict"
+  done
+
+  if [ "$rc" -eq 0 ]; then
+    printf '%s\n' "alpine base guard: all Dockerfiles compliant"
+  else
+    printf '%s\n' "alpine base guard: violations found"
+  fi
+  return "$rc"
+}
+
+main() {
+  local cmd="${1:-scan}"
+  [ "$#" -gt 0 ] && shift || true
+
+  case "$cmd" in
+    classify) classify "$@" ;;
+    parse-froms) parse_froms "$@" ;;
+    detect-exception) detect_exception "$@" ;;
+    evaluate) evaluate ;;
+    scan) scan "$@" ;;
+    *)
+      log "alpine base guard: unknown subcommand: ${cmd}"
+      log "usage: alpine_base_guard.sh {classify|parse-froms|detect-exception|evaluate|scan}"
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/bats/alpine_base_guard.bats
+++ b/tests/bats/alpine_base_guard.bats
@@ -1,0 +1,328 @@
+#!/usr/bin/env bats
+
+load './test_helper.bash'
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/ci/alpine_base_guard.sh"
+
+write_fixture() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" > "$path"
+}
+
+# --- classify (positive) ----------------------------------------------------
+
+@test "classify treats an alpine tag with a digest suffix as alpine (positive)" {
+  run bash "$SCRIPT" classify 'oven/bun:1.3.14-alpine@sha256:abc123'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
+@test "classify treats a compound alpine tag as alpine (positive)" {
+  run bash "$SCRIPT" classify 'node:20-alpine3.19'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
+@test "classify treats a bare alpine repository as alpine (positive)" {
+  run bash "$SCRIPT" classify 'alpine'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
+@test "classify treats a tagged alpine repository as alpine (positive)" {
+  run bash "$SCRIPT" classify 'alpine:3.19'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
+@test "classify treats a fully qualified alpine repository as alpine (positive)" {
+  run bash "$SCRIPT" classify 'docker.io/library/alpine:3.19'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
+@test "classify treats scratch as scratch (positive)" {
+  run bash "$SCRIPT" classify 'scratch'
+  [ "$status" -eq 0 ]
+  [ "$output" = "scratch" ]
+}
+
+# --- classify (negative) -----------------------------------------------------
+
+@test "classify treats the Playwright jammy vendor image as non-alpine (negative)" {
+  run bash "$SCRIPT" classify 'mcr.microsoft.com/playwright:v1.59.1-jammy'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+@test "classify treats ubuntu as non-alpine (negative)" {
+  run bash "$SCRIPT" classify 'ubuntu:22.04'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+# --- classify (edge) ---------------------------------------------------------
+
+@test "classify reports an unresolved build-arg base as unknown (edge)" {
+  run bash "$SCRIPT" classify '${BASE_IMAGE}'
+  [ "$status" -eq 0 ]
+  [ "$output" = "unknown" ]
+}
+
+@test "classify does not mistake a registry port for a tag (edge)" {
+  run bash "$SCRIPT" classify 'registry:5000/team/app:1.0'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+@test "classify treats an alpine repo behind a bare registry port as alpine (edge)" {
+  run bash "$SCRIPT" classify 'registry:5000/library/alpine'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
+@test "classify treats an empty ref as unknown (edge)" {
+  run bash "$SCRIPT" classify ''
+  [ "$status" -eq 0 ]
+  [ "$output" = "unknown" ]
+}
+
+@test "classify requires alpine in the final repo segment or tag, not a parent path (edge)" {
+  # Default-deny: an Alpine-based image that does not advertise `alpine` in the
+  # tag or final repo segment (e.g. alpine/git) still needs an explicit marker.
+  run bash "$SCRIPT" classify 'alpine/git:2.40'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+# --- parse-froms (positive) --------------------------------------------------
+
+@test "parse-froms prints the single external base ref (positive)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.single"
+  write_fixture "$dockerfile" \
+    'FROM node:20-alpine' \
+    'RUN echo hi'
+
+  run bash "$SCRIPT" parse-froms "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "$output" = "node:20-alpine" ]
+}
+
+@test "parse-froms skips the platform flag and prints the ref (edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.platform"
+  write_fixture "$dockerfile" \
+    'FROM --platform=$BUILDPLATFORM node:20-alpine AS b'
+
+  run bash "$SCRIPT" parse-froms "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "$output" = "node:20-alpine" ]
+}
+
+# --- parse-froms (negative / edge) -------------------------------------------
+
+@test "parse-froms skips references to earlier build stages (edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.multistage"
+  write_fixture "$dockerfile" \
+    'FROM node:20-alpine AS build' \
+    'RUN echo build' \
+    'FROM build' \
+    'RUN echo final'
+
+  run bash "$SCRIPT" parse-froms "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "$output" = "node:20-alpine" ]
+}
+
+@test "parse-froms never mistakes a COPY --from stage for a base ref (edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.copyfrom"
+  write_fixture "$dockerfile" \
+    'FROM node:20-alpine AS build' \
+    'RUN echo build' \
+    'FROM alpine:3.19' \
+    'COPY --from=build /app /app'
+
+  run bash "$SCRIPT" parse-froms "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "node:20-alpine" ]
+  [ "${lines[1]}" = "alpine:3.19" ]
+  [ "${#lines[@]}" -eq 2 ]
+  [[ "$output" != *build* ]]
+}
+
+@test "parse-froms prints nothing for a missing file (edge)" {
+  run bash "$SCRIPT" parse-froms "$BATS_TEST_TMPDIR/Dockerfile.absent"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- detect-exception --------------------------------------------------------
+
+@test "detect-exception returns the inline marker reason (negative-waived)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.exception"
+  write_fixture "$dockerfile" \
+    '# alpine-exception: glibc-only vendor base' \
+    'FROM ubuntu:22.04'
+
+  run bash "$SCRIPT" detect-exception "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "$output" = "glibc-only vendor base" ]
+}
+
+@test "detect-exception ignores a bare marker with no reason (edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.bare"
+  write_fixture "$dockerfile" \
+    '# alpine-exception:' \
+    'FROM ubuntu:22.04'
+
+  run bash "$SCRIPT" detect-exception "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "detect-exception ignores a whitespace-only marker reason (edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.spaces"
+  write_fixture "$dockerfile" \
+    '# alpine-exception:    ' \
+    'FROM ubuntu:22.04'
+
+  run bash "$SCRIPT" detect-exception "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "detect-exception finds a marker placed below the FROM line (negative-waived)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.below"
+  write_fixture "$dockerfile" \
+    'FROM ubuntu:22.04' \
+    '# alpine-exception: glibc-only vendor base'
+
+  run bash "$SCRIPT" detect-exception "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "$output" = "glibc-only vendor base" ]
+}
+
+@test "detect-exception falls back to the PR label reason (negative-waived)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.label"
+  write_fixture "$dockerfile" \
+    'FROM ubuntu:22.04'
+
+  run env ALPINE_EXCEPTION_LABEL=true bash "$SCRIPT" detect-exception "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ "$output" = "PR label 'docker-alpine-exception' applied" ]
+}
+
+@test "detect-exception returns empty with no marker and no label (negative)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.none"
+  write_fixture "$dockerfile" \
+    'FROM ubuntu:22.04'
+
+  run bash "$SCRIPT" detect-exception "$dockerfile"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- evaluate ----------------------------------------------------------------
+
+@test "evaluate passes an alpine base (positive)" {
+  run env BASE_CLASS=alpine EXCEPTION_REASON= bash "$SCRIPT" evaluate
+  [ "$status" -eq 0 ]
+  assert_output_contains 'PASS: base image is Alpine-compliant'
+}
+
+@test "evaluate passes a scratch base (positive)" {
+  run env BASE_CLASS=scratch EXCEPTION_REASON= bash "$SCRIPT" evaluate
+  [ "$status" -eq 0 ]
+  assert_output_contains 'PASS: base image is Alpine-compliant'
+}
+
+@test "evaluate fails a non-alpine base without an exception (negative)" {
+  run env BASE_CLASS=non-alpine EXCEPTION_REASON= OFFENDING_REF='ubuntu:22.04' \
+    bash "$SCRIPT" evaluate
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL: non-Alpine base image; migrate to an Alpine variant or document an exception'
+  assert_output_contains '(offending base: ubuntu:22.04)'
+}
+
+@test "evaluate waives a non-alpine base with a documented exception (negative-waived)" {
+  run env BASE_CLASS=non-alpine EXCEPTION_REASON='glibc-only vendor base' \
+    bash "$SCRIPT" evaluate
+  [ "$status" -eq 0 ]
+  assert_output_contains 'EXCEPTION: non-Alpine base waived by documented exception: glibc-only vendor base'
+}
+
+@test "evaluate fails an unknown base without an exception (edge)" {
+  run env BASE_CLASS=unknown EXCEPTION_REASON= bash "$SCRIPT" evaluate
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL: non-Alpine base image; migrate to an Alpine variant or document an exception'
+}
+
+# --- scan (explicit fixture args only; hermetic) -----------------------------
+#
+# scan's git-discovery branch (no args) is the path the CI workflow exercises;
+# it is intentionally validated by the live workflow run rather than here, so
+# these tests stay hermetic and pass inside the container with no .git present.
+
+@test "scan passes an Alpine fixture file (positive)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.alpine"
+  write_fixture "$dockerfile" \
+    'FROM node:20-alpine' \
+    'RUN echo hi'
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  [ "$status" -eq 0 ]
+  assert_output_contains 'PASS'
+}
+
+@test "scan fails a Debian fixture file with no marker (negative)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.debian"
+  write_fixture "$dockerfile" \
+    'FROM debian:bookworm' \
+    'RUN echo hi'
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+}
+
+@test "scan waives a Debian fixture file carrying an inline marker (negative-waived)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.debian-waived"
+  write_fixture "$dockerfile" \
+    '# alpine-exception: glibc-only vendor base' \
+    'FROM debian:bookworm' \
+    'RUN echo hi'
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  [ "$status" -eq 0 ]
+  assert_output_contains 'EXCEPTION'
+}
+
+@test "scan fails when any of multiple fixtures is an unwaived violation (edge)" {
+  local good="$BATS_TEST_TMPDIR/Dockerfile.good"
+  local bad="$BATS_TEST_TMPDIR/Dockerfile.bad"
+  write_fixture "$good" \
+    'FROM node:20-alpine'
+  write_fixture "$bad" \
+    'FROM ubuntu:22.04'
+
+  run bash "$SCRIPT" scan "$good" "$bad"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+}
+
+@test "scan fails an unresolved build-arg base (edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.arg"
+  write_fixture "$dockerfile" \
+    'FROM ${BASE_IMAGE}'
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+}
+
+@test "scan fails closed on an explicit path that does not exist (negative)" {
+  run bash "$SCRIPT" scan "$BATS_TEST_TMPDIR/Dockerfile.does-not-exist"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+  assert_output_contains 'not found'
+}

--- a/tests/bats/alpine_base_guard.bats
+++ b/tests/bats/alpine_base_guard.bats
@@ -48,6 +48,12 @@ write_fixture() {
   [ "$output" = "scratch" ]
 }
 
+@test "classify treats a bare alpine tag such as nginx:alpine as alpine (positive)" {
+  run bash "$SCRIPT" classify 'nginx:alpine'
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpine" ]
+}
+
 # --- classify (negative) -----------------------------------------------------
 
 @test "classify treats the Playwright jammy vendor image as non-alpine (negative)" {
@@ -58,6 +64,24 @@ write_fixture() {
 
 @test "classify treats ubuntu as non-alpine (negative)" {
   run bash "$SCRIPT" classify 'ubuntu:22.04'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+@test "classify rejects a non-Alpine image whose tag merely contains alpine (security/negative)" {
+  run bash "$SCRIPT" classify 'ubuntu:notalpine'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+@test "classify rejects an alpine-lookalike tag fragment (security/negative)" {
+  run bash "$SCRIPT" classify 'node:20-bookworm-alpinexx'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+@test "classify rejects a hyphenated alpine-lookalike tag (security/negative)" {
+  run bash "$SCRIPT" classify 'debian:3.20-alpine-fake'
   [ "$status" -eq 0 ]
   [ "$output" = "non-alpine" ]
 }
@@ -148,6 +172,21 @@ write_fixture() {
   [ "${lines[1]}" = "alpine:3.19" ]
   [ "${#lines[@]}" -eq 2 ]
   [[ "$output" != *build* ]]
+}
+
+@test "parse-froms ignores an AS alias hidden in an inline comment (security/edge)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.comment-spoof"
+  write_fixture "$dockerfile" \
+    'FROM alpine:3.19 # AS ubuntu' \
+    'FROM ubuntu'
+
+  run bash "$SCRIPT" parse-froms "$dockerfile"
+  [ "$status" -eq 0 ]
+  # The commented-out "AS ubuntu" must not register a stage alias, so the real
+  # non-Alpine base on the next line is surfaced rather than skipped as a stage.
+  [ "${lines[0]}" = "alpine:3.19" ]
+  [ "${lines[1]}" = "ubuntu" ]
+  [ "${#lines[@]}" -eq 2 ]
 }
 
 @test "parse-froms prints nothing for a missing file (edge)" {
@@ -325,4 +364,42 @@ write_fixture() {
   [ "$status" -eq 1 ]
   assert_output_contains 'FAIL'
   assert_output_contains 'not found'
+}
+
+@test "scan fails closed on a non-Alpine base whose tag contains alpine as a substring (security/negative)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.tag-substring"
+  write_fixture "$dockerfile" \
+    'FROM ubuntu:notalpine'
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+}
+
+@test "scan fails closed when an inline comment spoofs an AS stage alias (security/negative)" {
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.comment-spoof-scan"
+  write_fixture "$dockerfile" \
+    'FROM alpine:3.19 # AS ubuntu' \
+    'FROM ubuntu'
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+}
+
+@test "scan fails closed on an existing but unreadable Dockerfile (security/negative)" {
+  [ "$(id -u)" -eq 0 ] && skip 'root bypasses file permission checks'
+  # Alpine content would PASS if readable, so a failure here is unambiguously
+  # caused by unreadability rather than a non-Alpine base.
+  local dockerfile="$BATS_TEST_TMPDIR/Dockerfile.unreadable"
+  write_fixture "$dockerfile" \
+    'FROM node:20-alpine'
+  chmod 000 "$dockerfile"
+
+  run bash "$SCRIPT" scan "$dockerfile"
+  chmod 644 "$dockerfile"
+
+  [ "$status" -eq 1 ]
+  assert_output_contains 'FAIL'
+  assert_output_contains 'unreadable'
 }

--- a/tests/bats/alpine_base_guard.bats
+++ b/tests/bats/alpine_base_guard.bats
@@ -86,6 +86,18 @@ write_fixture() {
   [ "$output" = "non-alpine" ]
 }
 
+@test "classify rejects an alpine-suffix tag with trailing junk after a digit (security/negative)" {
+  run bash "$SCRIPT" classify 'ubuntu:1.0-alpine9evil'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
+@test "classify rejects an alpine-version tag with a trailing word (security/negative)" {
+  run bash "$SCRIPT" classify 'ubuntu:alpine3.19-backdoor'
+  [ "$status" -eq 0 ]
+  [ "$output" = "non-alpine" ]
+}
+
 # --- classify (edge) ---------------------------------------------------------
 
 @test "classify reports an unresolved build-arg base as unknown (edge)" {


### PR DESCRIPTION
## Summary

Implements the remaining, not-yet-built part of #40: a **CI regression guard that fails when a Dockerfile uses a non-Alpine base image** without a documented exception, plus the Alpine base-image **policy docs**.

The Alpine *migration* itself is already on `main` (the root `Dockerfile` is `oven/bun:1.3.14-alpine`, PR #37), and the Docker **image-size / build-performance** reporting criterion of #40 is delivered separately by **#53** (which closes #48). This PR adds the missing enforcement guard and its documentation.

## What's added

- **`scripts/ci/alpine_base_guard.sh`** — a hermetic, static guard (no network, no Docker). Subcommands `classify` / `parse-froms` / `detect-exception` / `evaluate` / `scan`. Default-deny: any non-Alpine base must be waived. Handles digests, `registry:port`, multi-stage local-stage refs, `--platform`, `${VAR}` bases, and `COPY --from`.
- **`.github/workflows/alpine-base-guard.yml`** — hardened workflow: `permissions: {}` top-level + `contents: read`, SHA-pinned checkout, `persist-credentials: false`, plus a **tamper-evidence self-test** step so a gutted script fails the job rather than passing vacuously.
- **`tests/bats/alpine_base_guard.bats`** — 35 Bats cases (positive / negative / negative-waived / edge), auto-discovered by `make test-bats`.
- **`Dockerfile.playwright`** — inline `# alpine-exception:` marker documenting the glibc-only Playwright base (no Alpine/musl variant published).
- **`CONTRIBUTING.md`** — Alpine policy, the recognised filename set (`Dockerfile`, `Dockerfile.<suffix>`, `<prefix>.Dockerfile`, `Containerfile`), the inline-marker + label exception mechanism, and the file-scoped-waiver caveat.

## Verification (local)

- `bun x bats tests/bats/alpine_base_guard.bats` → 35/35 pass
- `make test-bats` (CI container) → 52/52 pass (new guard + existing suites)
- `shellcheck scripts/ci/alpine_base_guard.sh` → clean
- `actionlint .github/workflows/alpine-base-guard.yml` → clean
- `bash scripts/ci/alpine_base_guard.sh scan` → `Dockerfile` PASS, `Dockerfile.playwright` waived EXCEPTION, exit 0
- A temp repo with `ubuntu`/`debian` bases under `Dockerfile`, `app.Dockerfile`, `Containerfile`, `svc/Dockerfile` → all FAIL (exit 1); all-Alpine repo → exit 0

## Notes

- Branched off `main` (not stacked on #53) so the full CI suite — which filters `branches: [main]` — actually runs on this PR.
- Part of #40 (does not auto-close, since the image-size/build-perf reporting criterion of #40 is in #53).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI guard that enforces Alpine base images across all Dockerfiles and documents the policy (part of #40). Non-Alpine bases now fail CI unless an inline `# alpine-exception: <reason>` is present or the `docker-alpine-exception` label is applied; the docs section was relocated to avoid PR conflicts.

- **New Features**
  - `scripts/ci/alpine_base_guard.sh`: hermetic static scan; supports multi-stage, digests, registry ports, `--platform`, and `${VAR}`; default-deny; requires Bash ≥ 4.
  - Hardened checks: tag match on token boundary and end-of-tag (blocks `notalpine`, `alpinexx`, `1.0-alpine9evil`, `alpine3.19-backdoor`), strips inline-comment spoofing of `AS <stage>`, fails closed on missing/unreadable files.
  - `.github/workflows/alpine-base-guard.yml`: minimal permissions, SHA-pinned checkout, and a tamper-evidence self-test.
  - `tests/bats/alpine_base_guard.bats`: coverage for positive/negative/security paths, including spoof-tag regressions.
  - `CONTRIBUTING.md`: Alpine policy and exception mechanism; recognized files (incl. `Containerfile.<suffix>`); section moved to its own anchor to avoid CI-doc PR merge conflicts; `Dockerfile.playwright` carries an inline exception with reason.

- **Migration**
  - Run locally: `bash scripts/ci/alpine_base_guard.sh scan`.
  - If a non-Alpine base is required, add `# alpine-exception: <reason>` to the file, or use the `docker-alpine-exception` PR label only for emergencies.

<sup>Written for commit 267c9d6b2716f398e59a03cc28c24992b9915cf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

