### PR TITLE
ci(#64): shard mutation testing and parallelize CI to cut ~1h PR runtime

### DIFF
--- a/.github/workflows/alpine-base-guard.yml
+++ b/.github/workflows/alpine-base-guard.yml
@@ -20,6 +20,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/autoprerelease.yml
+++ b/.github/workflows/autoprerelease.yml
@@ -8,6 +8,10 @@ on:
       - 'package.json'
       - 'CHANGELOG.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -8,6 +8,10 @@ on:
       - 'package.json'
       - 'CHANGELOG.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/bats-testing.yml
+++ b/.github/workflows/bats-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bats:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codecov:
     runs-on: ubuntu-latest
@@ -30,7 +34,7 @@ jobs:
 
       - name: Start docker test environment
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
       - name: Run unit tests
         if: steps.project.outputs.present == 'true'

--- a/.github/workflows/dependency-cruiser.yml
+++ b/.github/workflows/dependency-cruiser.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-cruiser:
     runs-on: ubuntu-latest
@@ -27,7 +31,7 @@ jobs:
 
       - name: Start docker test environment
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
       - name: Run dependency-cruiser
         if: steps.project.outputs.present == 'true'

--- a/.github/workflows/dependency-cruiser.yml
+++ b/.github/workflows/dependency-cruiser.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run dependency-cruiser
         if: steps.project.outputs.present == 'true'
-        run: make lint-dep-cruiser
+        run: make lint-deps
 
       - name: Stop docker test environment
         if: always() && steps.project.outputs.present == 'true'

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -8,6 +8,10 @@ on:
       - '**.png'
       - '**.webp'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -31,7 +35,7 @@ jobs:
 
       - name: Start docker test environment
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
       - name: Run integration tests
         if: steps.project.outputs.present == 'true'

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   memory-leak-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Detect runtime project files
         id: project
@@ -86,6 +88,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Detect runtime project files
         id: project

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Detect runtime project files
         id: project
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload shard report
         if: steps.project.outputs.present == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mutation-shard-${{ matrix.index }}
           path: reports/mutation/mutation-shard-${{ matrix.index }}.json
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Detect runtime project files
         id: project
@@ -110,7 +110,7 @@ jobs:
 
       - name: Download shard reports
         if: steps.project.outputs.present == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: mutation-shard-*
           path: reports/mutation

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -5,11 +5,28 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  mutation-testing:
+  shard:
+    name: shard ${{ matrix.index }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # To change shard count, keep this list and MUTATION_SHARD_TOTAL (here and
+        # in the merge job) in lock-step: index must be [0 .. TOTAL-1]. A mismatch
+        # fails closed at the merge gate's shard-count/index check, never silently.
+        index: [0, 1, 2, 3]
+    env:
+      MUTATION_SHARD_TOTAL: '4'
+      MUTATION_SHARD_INDEX: ${{ matrix.index }}
 
     steps:
       - name: Checkout code
@@ -28,13 +45,86 @@ jobs:
         if: steps.project.outputs.present != 'true'
         run: echo "Skipping mutation testing because this bootstrap PR does not include the project runtime files yet."
 
-      - name: Start docker test environment
+      - name: Start bun service
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
-      - name: Run mutation testing
+      - name: Run mutation shard
         if: steps.project.outputs.present == 'true'
-        run: make test-mutation
+        run: make test-mutation-shard
+
+      - name: Copy shard report
+        if: steps.project.outputs.present == 'true'
+        run: make copy-mutation-report
+
+      - name: Upload shard report
+        if: steps.project.outputs.present == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-shard-${{ matrix.index }}
+          path: reports/mutation/mutation-shard-${{ matrix.index }}.json
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Stop docker test environment
+        if: always() && steps.project.outputs.present == 'true'
+        run: make down
+
+  merge:
+    name: merge and enforce gate
+    needs: shard
+    # Run even when a shard failed so the gate fails CLOSED. Without this the job
+    # would be SKIPPED on shard failure, and branch protection treats a skipped
+    # required check as passing — silently bypassing the mutation gate.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MUTATION_SHARD_TOTAL: '4'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect runtime project files
+        id: project
+        run: |
+          if [[ -f package.json && -f bun.lock ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip mutation gate
+        if: steps.project.outputs.present != 'true'
+        run: echo "Skipping mutation gate because this bootstrap PR does not include the project runtime files yet."
+
+      - name: Fail if any mutation shard did not succeed
+        if: steps.project.outputs.present == 'true' && needs.shard.result != 'success'
+        run: |
+          echo "::error::Mutation shards did not all succeed (result=${{ needs.shard.result }}); failing the gate."
+          exit 1
+
+      - name: Download shard reports
+        if: steps.project.outputs.present == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: mutation-shard-*
+          path: reports/mutation
+          merge-multiple: true
+
+      - name: Start bun service
+        if: steps.project.outputs.present == 'true'
+        run: make start-bun
+
+      - name: Stage shard reports in the container
+        if: steps.project.outputs.present == 'true'
+        run: make stage-mutation-reports
+
+      - name: Merge reports and enforce mutation-score gate
+        if: steps.project.outputs.present == 'true'
+        run: make merge-mutation-reports
 
       - name: Stop docker test environment
         if: always() && steps.project.outputs.present == 'true'

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -102,8 +102,10 @@ jobs:
 
       - name: Fail if any mutation shard did not succeed
         if: steps.project.outputs.present == 'true' && needs.shard.result != 'success'
+        env:
+          SHARD_RESULT: ${{ needs.shard.result }}
         run: |
-          echo "::error::Mutation shards did not all succeed (result=${{ needs.shard.result }}); failing the gate."
+          echo "::error::Mutation shards did not all succeed (result=$SHARD_RESULT); failing the gate."
           exit 1
 
       - name: Download shard reports

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -42,10 +42,9 @@ jobs:
         if: steps.project.outputs.present != 'true'
         run: echo "Skipping performance tests because this bootstrap PR does not include the project runtime files yet."
 
-      - name: Start bun service
-        if: steps.project.outputs.present == 'true'
-        run: make start-bun
-
+      # Lighthouse targets run in their own `docker compose run --rm` container
+      # (RUN_BUN_SH) and build Storybook themselves, so no long-lived service is
+      # needed here.
       - name: Run ${{ matrix.formFactor }} Lighthouse audit
         if: steps.project.outputs.present == 'true'
         run: make lighthouse-${{ matrix.formFactor }}

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -5,11 +5,20 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   performance:
+    name: lighthouse ${{ matrix.formFactor }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        formFactor: [desktop, mobile]
     env:
       CI: true
       INSTALL_CHROMIUM: 'true'
@@ -33,17 +42,13 @@ jobs:
         if: steps.project.outputs.present != 'true'
         run: echo "Skipping performance tests because this bootstrap PR does not include the project runtime files yet."
 
-      - name: Start docker test environment
+      - name: Start bun service
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
-      - name: Run desktop Lighthouse audit
+      - name: Run ${{ matrix.formFactor }} Lighthouse audit
         if: steps.project.outputs.present == 'true'
-        run: make lighthouse-desktop
-
-      - name: Run mobile Lighthouse audit
-        if: steps.project.outputs.present == 'true'
-        run: make lighthouse-mobile
+        run: make lighthouse-${{ matrix.formFactor }}
 
       - name: Stop docker test environment
         if: always() && steps.project.outputs.present == 'true'

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static:
     runs-on: ubuntu-latest
@@ -29,7 +33,7 @@ jobs:
 
       - name: Start docker test environment
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
       - name: Run ESLint
         if: steps.project.outputs.present == 'true'

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest
@@ -29,7 +33,7 @@ jobs:
 
       - name: Start docker test environment
         if: steps.project.outputs.present == 'true'
-        run: make start
+        run: make start-bun
 
       - name: Run unit tests
         if: steps.project.outputs.present == 'true'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/yaml-formater.yml
+++ b/.github/workflows/yaml-formater.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   yamlfmt:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ React **export identifiers** remain PascalCase (`export const UiButton`,
 `export const AuthSkeleton`) because that is the React component naming convention; only the
 file and directory _paths_ are kebab-case. The public component API is unchanged.
 
-This convention is enforced by `make lint-dep-cruiser` via three `error`-severity rules:
+This convention is enforced by `make lint-deps` via three `error`-severity rules:
 `no-uppercase-paths` (any uppercase character in a governed `src/` path), `component-name-kebab-case`
 (top-level `src/components/` directory names), and `test-name-kebab-case`
 (`tests/{unit,integration,e2e,visual}/` paths). Any violation causes the gate to exit non-zero
@@ -205,7 +205,7 @@ orphan, boundary, barrel, and type-only discipline; it does not re-run the exist
 #### Running it locally
 
 ```bash
-make lint-dep-cruiser
+make lint-deps
 ```
 
 No extra setup is required beyond the existing docker-compose `bun` workflow — `make start`
@@ -214,12 +214,12 @@ brings the service up and the target runs inside it. The check is also part of t
 workflow:
 
 ```bash
-lint: lint-next lint-tsc lint-md format-check lint-dep-ranges lint-test-structure lint-dep-cruiser
+lint: lint-next lint-tsc lint-md format-check lint-dep-ranges lint-test-structure lint-deps
 ```
 
 #### CI enforcement and required status check
 
-The dedicated `.github/workflows/dependency-cruiser.yml` workflow runs `make lint-dep-cruiser` on
+The dedicated `.github/workflows/dependency-cruiser.yml` workflow runs `make lint-deps` on
 every pull request targeting `main` — the same command and the same committed
 `.dependency-cruiser.js` policy as the local run, so local and CI always agree.
 
@@ -230,7 +230,7 @@ before merging**. The check appears in the list after the workflow has run at le
 
 Once enabled, any pull request that introduces a graph violation fails the check and cannot be
 merged until the violation is fixed. The failure output names the offending file and the violated
-rule, identical to what `make lint-dep-cruiser` prints locally. The gate remains zero-tolerance:
+rule, identical to what `make lint-deps` prints locally. The gate remains zero-tolerance:
 no `depcruise-baseline` file exists to suppress findings.
 
 #### Reading the output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,48 @@ Common fixes:
 
 IDE/editor integration and visual/graph reporting (`dot`/`archi` output) are out of scope.
 
+### CI speed and the mutation-testing gate
+
+GitHub runs the pull-request workflows in parallel, so PR feedback is gated by the slowest single
+job. Two things keep that fast without dropping or weakening any check — every gate still runs on
+every PR.
+
+**Cancel superseded runs.** Every workflow declares a `concurrency` group keyed on the workflow and
+the PR (or ref) with `cancel-in-progress: true`, so pushing a new commit aborts the previous run for
+that PR instead of letting it finish. The release workflows (`autorelease`, `autoprerelease`) use
+`cancel-in-progress: false` so a half-finished release is never cancelled. Bun-only jobs start just
+the `bun` service with `make start-bun` rather than `make start`, which also builds the Storybook and
+Playwright images they do not need.
+
+**Mutation testing is sharded, not slowed.** Stryker over the whole component surface took close to
+an hour as one job. `mutation-testing.yml` now fans `make test-mutation-shard` across a 4-way matrix;
+each shard mutates a deterministic, disjoint slice of the same file set (`stryker.shard.config.mjs`)
+and uploads a per-shard JSON report. A final `merge and enforce gate` job runs
+`make merge-mutation-reports`, which unions the shard reports and re-enforces the **unchanged**
+Stryker `break` threshold (`stryker.config.mjs` — `break: 80`) over the whole set, computing the
+mutation score exactly as an unsharded run would. Sharding by file is score-preserving: each mutant
+runs against the full suite regardless of which shard owns it. A missing shard report makes the merge
+fail (it never passes the gate vacuously). The merge math is unit-tested in
+`tests/unit/mutation-report.test.ts`.
+
+Run it locally either way:
+
+```bash
+make test-mutation                                   # full, gated, single-process run
+# or reproduce the sharded CI flow against a running bun service:
+make start-bun
+make test-mutation-shard MUTATION_SHARD_TOTAL=4 MUTATION_SHARD_INDEX=0   # repeat for 1..3
+make merge-mutation-reports MUTATION_SHARD_TOTAL=4
+```
+
+**Required status checks.** When mutation testing is a required check, the gate is now the
+`merge and enforce gate` job (the old single `mutation-testing` check no longer exists). A maintainer
+must update **Settings → Branches → Branch protection rules** to require that job, plus the parallel
+Lighthouse matrix jobs (`lighthouse desktop` / `lighthouse mobile`), so branch protection points at
+jobs that actually run. The merge job runs `if: ${{ !cancelled() }}` and fails closed if any shard
+did not succeed (a skipped required check would otherwise count as a pass), so requiring just
+`merge and enforce gate` is sufficient — a crashed shard turns the gate red rather than bypassing it.
+
 ### Commit your update
 
 Commit the changes once you are happy with them.

--- a/Makefile
+++ b/Makefile
@@ -163,14 +163,13 @@ copy-coverage: ## Copy the Jest coverage directory from the docker container.
 test-mutation: ## Run mutation tests inside the docker container.
 	$(BUN_X) stryker run
 
-test-mutation-shard: ## Run mutation shard MUTATION_SHARD_INDEX of MUTATION_SHARD_TOTAL inside the docker container.
-	@env_flags="-e MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL)"; \
-	container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
-	if [ -n "$$container_id" ]; then \
-		$(DOCKER_COMPOSE) exec -T $$env_flags bun bun x stryker run stryker.shard.config.mjs; \
-	else \
-		$(DOCKER_COMPOSE) run --rm $$env_flags bun bun x stryker run stryker.shard.config.mjs; \
-	fi
+test-mutation-shard: ## Run mutation shard MUTATION_SHARD_INDEX of MUTATION_SHARD_TOTAL in the running bun container.
+	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
+	if [ -z "$$container_id" ]; then \
+		echo "bun service is not running; run 'make start-bun' first so the shard report can be copied out"; \
+		exit 1; \
+	fi; \
+	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun x stryker run stryker.shard.config.mjs
 
 copy-mutation-report: ## Copy mutation shard MUTATION_SHARD_INDEX's JSON report from the docker container to the host.
 	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
@@ -190,13 +189,13 @@ stage-mutation-reports: ## Copy host shard reports into the running bun containe
 	$(DOCKER_COMPOSE) exec -T bun mkdir -p $(MUTATION_REPORTS_DIR); \
 	$(DOCKER_COMPOSE) cp "$(MUTATION_REPORTS_DIR)/." "bun:/app/$(MUTATION_REPORTS_DIR)"
 
-merge-mutation-reports: ## Merge mutation shard reports and enforce the mutation-score gate inside the docker container.
+merge-mutation-reports: ## Merge mutation shard reports and enforce the mutation-score gate in the running bun container.
 	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
-	if [ -n "$$container_id" ]; then \
-		$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts; \
-	else \
-		$(DOCKER_COMPOSE) run --rm -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts; \
-	fi
+	if [ -z "$$container_id" ]; then \
+		echo "bun service is not running; run 'make start-bun' first"; \
+		exit 1; \
+	fi; \
+	$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts
 
 test-memory-leak: ## Start the app and run Memlab inside a Docker container.
 	INSTALL_CHROMIUM=true $(DOCKER_COMPOSE) build bun

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ RCA_SCOPE = src/
 RCA_EXCLUDES = **/node_modules/** **/dist/** **/build/**
 METRICS_POLICY_PATH = config/metrics-policy.json
 
+# Mutation testing shards: CI fans test-mutation-shard out into MUTATION_SHARD_TOTAL
+# parallel jobs, then merge-mutation-reports re-enforces the real break gate once
+# over the union of every shard. See stryker.shard.config.mjs and
+# scripts/ci/merge-mutation-reports.ts.
+MUTATION_SHARD_TOTAL ?= 1
+MUTATION_SHARD_INDEX ?= 0
+MUTATION_REPORTS_DIR = reports/mutation
+
 # Misc
 .DEFAULT_GOAL = help
 .RECIPEPREFIX +=
@@ -27,8 +35,9 @@ METRICS_POLICY_PATH = config/metrics-policy.json
 	storybook-start storybook-build generate-ts-doc test-e2e test-e2e-local \
 	test-unit test-integration copy-coverage test-mutation test-memory-leak test-visual \
 	lighthouse-desktop lighthouse-mobile install update playwright-install test-bats \
-	up down sh ps logs new-logs start stop build-k6-docker load-tests run-storybook-playwright \
-	lint-dep-ranges lint-dep-cruiser lint-metrics lint-metrics-run
+	up down sh ps logs new-logs start start-bun stop build-k6-docker load-tests run-storybook-playwright \
+	lint-dep-ranges lint-dep-cruiser lint-metrics lint-metrics-run \
+	test-mutation-shard copy-mutation-report stage-mutation-reports merge-mutation-reports
 
 PLAYWRIGHT_TEST_ARGS =
 
@@ -154,6 +163,41 @@ copy-coverage: ## Copy the Jest coverage directory from the docker container.
 test-mutation: ## Run mutation tests inside the docker container.
 	$(BUN_X) stryker run
 
+test-mutation-shard: ## Run mutation shard MUTATION_SHARD_INDEX of MUTATION_SHARD_TOTAL inside the docker container.
+	@env_flags="-e MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL)"; \
+	container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
+	if [ -n "$$container_id" ]; then \
+		$(DOCKER_COMPOSE) exec -T $$env_flags bun bun x stryker run stryker.shard.config.mjs; \
+	else \
+		$(DOCKER_COMPOSE) run --rm $$env_flags bun bun x stryker run stryker.shard.config.mjs; \
+	fi
+
+copy-mutation-report: ## Copy mutation shard MUTATION_SHARD_INDEX's JSON report from the docker container to the host.
+	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
+	if [ -z "$$container_id" ]; then \
+		echo "bun service is not running; start docker before copying the report"; \
+		exit 1; \
+	fi; \
+	mkdir -p $(MUTATION_REPORTS_DIR); \
+	$(DOCKER_COMPOSE) cp "bun:/app/$(MUTATION_REPORTS_DIR)/mutation-shard-$(MUTATION_SHARD_INDEX).json" "$(MUTATION_REPORTS_DIR)/mutation-shard-$(MUTATION_SHARD_INDEX).json"
+
+stage-mutation-reports: ## Copy host shard reports into the running bun container ahead of the merge gate.
+	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
+	if [ -z "$$container_id" ]; then \
+		echo "bun service is not running; start docker before staging reports"; \
+		exit 1; \
+	fi; \
+	$(DOCKER_COMPOSE) exec -T bun mkdir -p $(MUTATION_REPORTS_DIR); \
+	$(DOCKER_COMPOSE) cp "$(MUTATION_REPORTS_DIR)/." "bun:/app/$(MUTATION_REPORTS_DIR)"
+
+merge-mutation-reports: ## Merge mutation shard reports and enforce the mutation-score gate inside the docker container.
+	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
+	if [ -n "$$container_id" ]; then \
+		$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts $(MUTATION_REPORTS_DIR); \
+	else \
+		$(DOCKER_COMPOSE) run --rm -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts $(MUTATION_REPORTS_DIR); \
+	fi
+
 test-memory-leak: ## Start the app and run Memlab inside a Docker container.
 	INSTALL_CHROMIUM=true $(DOCKER_COMPOSE) build bun
 	@$(RUN_BUN_SH) '\
@@ -214,6 +258,9 @@ new-logs: ## Show live docker compose logs without history.
 	@$(DOCKER_COMPOSE) logs --tail=0 --follow
 
 start: up ## Start docker.
+
+start-bun: ## Build and start only the Bun service (skips Storybook/Playwright builds for bun-only jobs).
+	$(DOCKER_COMPOSE) up -d --build bun
 
 stop: ## Stop docker services.
 	$(DOCKER_COMPOSE) stop

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ MUTATION_REPORTS_DIR = reports/mutation
 	test-unit test-integration copy-coverage test-mutation test-memory-leak test-visual \
 	lighthouse-desktop lighthouse-mobile install update playwright-install test-bats \
 	up down sh ps logs new-logs start start-bun stop build-k6-docker load-tests run-storybook-playwright \
-	lint-dep-ranges lint-dep-cruiser lint-metrics lint-metrics-run \
+	lint-dep-ranges lint-deps lint-metrics lint-metrics-run \
 	test-mutation-shard copy-mutation-report stage-mutation-reports merge-mutation-reports
 
 PLAYWRIGHT_TEST_ARGS =
@@ -61,7 +61,7 @@ help:
 build: ## Build the project inside the docker container.
 	$(RUN_BUN) node ./build.config.mjs
 
-lint: lint-next lint-tsc lint-md format-check lint-dep-ranges lint-test-structure lint-dep-cruiser lint-metrics ## Run all linters inside the docker container.
+lint: lint-next lint-tsc lint-md format-check lint-dep-ranges lint-test-structure lint-deps lint-metrics ## Run all linters inside the docker container.
 
 lint-next: ## Run ESLint inside the docker container.
 	@$(RUN_BUN_SH) '\
@@ -99,7 +99,7 @@ lint-dep-ranges: ## Enforce caret (^) version ranges in package.json inside the 
 lint-test-structure: ## Verify every test file lives under the root tests/ tree.
 	sh ./scripts/check-test-structure.sh
 
-lint-dep-cruiser: ## Run dependency-cruiser graph-hygiene gate inside the docker container.
+lint-deps: ## Run dependency-cruiser graph-hygiene gate inside the docker container.
 	$(BUN_X) depcruise --config .dependency-cruiser.js src
 
 lint-metrics: ## Run rust-code-analysis complexity gate inside the rca container.

--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,9 @@ stage-mutation-reports: ## Copy host shard reports into the running bun containe
 merge-mutation-reports: ## Merge mutation shard reports and enforce the mutation-score gate inside the docker container.
 	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
 	if [ -n "$$container_id" ]; then \
-		$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts $(MUTATION_REPORTS_DIR); \
+		$(DOCKER_COMPOSE) exec -T -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts; \
 	else \
-		$(DOCKER_COMPOSE) run --rm -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts $(MUTATION_REPORTS_DIR); \
+		$(DOCKER_COMPOSE) run --rm -e MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) bun bun scripts/ci/merge-mutation-reports.ts; \
 	fi
 
 test-memory-leak: ## Start the app and run Memlab inside a Docker container.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the `src/` graph against cycles, orphans, cross-component barrel breaches, `src`
 imports, leaked stories/dev dependencies, and type-only violations. Run it locally with:
 
 ```bash
-make lint-dep-cruiser
+make lint-deps
 ```
 
 See the

--- a/agents.md
+++ b/agents.md
@@ -55,6 +55,12 @@ strength, Stryker), `make test-bats` (Makefile and CI shell flows), `make test-m
 (leaks), `make load-tests` (traffic, K6), and `make lighthouse-desktop` /
 `make lighthouse-mobile` (performance, accessibility, best practices).
 
+`make test-mutation` runs the full, gated Stryker suite locally. In CI it is sharded across a
+parallel matrix (`make test-mutation-shard`) and a final job merges the per-shard reports and
+re-enforces the same `break` threshold (`make merge-mutation-reports`) — same gate, much faster.
+Every workflow cancels superseded runs via `concurrency`, so a new push aborts the previous one.
+See CONTRIBUTING.md ("CI speed and the mutation-testing gate") for the full flow.
+
 ### Step 2 — Cover Every Applicable Scenario Class
 
 For each layer you touch, cover all three scenario classes that apply to the change. Positive

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -14,11 +14,22 @@
  * vacuously). The merge math lives in {@link ./mutation-report.ts}.
  */
 import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 import { type MutationReport, scoreReports } from './mutation-report';
 
 const SHARD_FILE = /^mutation-shard-\d+\.json$/;
+const PROJECT_ROOT = resolve(process.cwd());
+
+/** Resolve the report directory and prove it stays inside the project root. */
+function resolveReportDir(input: string): string {
+  const dir = resolve(PROJECT_ROOT, input);
+  const rel = relative(PROJECT_ROOT, dir);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`Refusing to read mutation reports outside the project root: ${dir}`);
+  }
+  return dir;
+}
 
 /** Read and parse every `mutation-shard-*.json` report in `dir`. */
 function loadShardReports(dir: string): { name: string; report: MutationReport }[] {
@@ -31,7 +42,7 @@ function loadShardReports(dir: string): { name: string; report: MutationReport }
 
   return entries
     .filter(name => SHARD_FILE.test(name))
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map(name => {
       const raw = readFileSync(join(dir, name), 'utf8');
       try {
@@ -49,15 +60,15 @@ async function resolveBreakThreshold(): Promise<number> {
   };
   const breakThreshold = base.thresholds?.break;
   if (typeof breakThreshold !== 'number') {
-    throw new Error(
-      'stryker.config.mjs does not define a numeric thresholds.break; refusing to gate without a known threshold.'
+    throw new TypeError(
+      'stryker.config.mjs has no numeric thresholds.break; refusing to gate without a threshold.'
     );
   }
   return breakThreshold;
 }
 
 async function main(): Promise<void> {
-  const dir = process.argv[2] ?? 'reports/mutation';
+  const dir = resolveReportDir(process.argv[2] ?? 'reports/mutation');
 
   // The expected shard count is mandatory: without it the completeness check
   // below would be skipped and any subset of shards scoring >= break would pass
@@ -65,7 +76,7 @@ async function main(): Promise<void> {
   const expectedShards = Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '', 10);
   if (!Number.isInteger(expectedShards) || expectedShards <= 0) {
     throw new Error(
-      'MUTATION_SHARD_TOTAL must be a positive integer so the gate can verify every shard is present.'
+      'MUTATION_SHARD_TOTAL must be a positive integer so the gate can verify every shard.'
     );
   }
 
@@ -102,8 +113,9 @@ async function main(): Promise<void> {
     [
       `Merged ${shards.length} mutation shard(s) over ${fileCount} source file(s):`,
       `  killed=${tally.killed} timeout=${tally.timeout} ` +
-        `survived=${tally.survived} noCoverage=${tally.noCoverage} ` +
-        `compileError=${tally.compileError} runtimeError=${tally.runtimeError} ignored=${tally.ignored}`,
+        `survived=${tally.survived} noCoverage=${tally.noCoverage}`,
+      `  compileError=${tally.compileError} runtimeError=${tally.runtimeError} ` +
+        `ignored=${tally.ignored}`,
       `  detected=${tally.detected} valid=${tally.valid} mutationScore=${score}%`,
       '',
     ].join('\n')
@@ -111,7 +123,7 @@ async function main(): Promise<void> {
 
   if (mutationScore < breakThreshold) {
     process.stderr.write(
-      `Mutation score ${score}% is below the break threshold ${breakThreshold}%. Failing the gate.\n`
+      `Mutation score ${score}% is below the break threshold ${breakThreshold}%. Gate failed.\n`
     );
     process.exitCode = 1;
     return;

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -14,22 +14,18 @@
  * vacuously). The merge math lives in {@link ./mutation-report.ts}.
  */
 import { readdirSync, readFileSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { type MutationReport, scoreReports } from './mutation-report';
 
 const SHARD_FILE = /^mutation-shard-\d+\.json$/;
-const PROJECT_ROOT = resolve(process.cwd());
 
-/** Resolve the report directory and prove it stays inside the project root. */
-function resolveReportDir(input: string): string {
-  const dir = resolve(PROJECT_ROOT, input);
-  const rel = relative(PROJECT_ROOT, dir);
-  if (rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(`Refusing to read mutation reports outside the project root: ${dir}`);
-  }
-  return dir;
-}
+// Fixed location of the shard reports, resolved from the working directory.
+// Deliberately NOT taken from argv or any other external input: a caller-
+// controlled path is a path-injection vector (Sonar S8707), and this gate only
+// ever reads its own shard reports. Keep in sync with the Makefile's
+// MUTATION_REPORTS_DIR.
+const REPORTS_DIR = resolve(process.cwd(), 'reports', 'mutation');
 
 /** Read and parse every `mutation-shard-*.json` report in `dir`. */
 function loadShardReports(dir: string): { name: string; report: MutationReport }[] {
@@ -68,7 +64,7 @@ async function resolveBreakThreshold(): Promise<number> {
 }
 
 async function main(): Promise<void> {
-  const dir = resolveReportDir(process.argv[2] ?? 'reports/mutation');
+  const dir = REPORTS_DIR;
 
   // The expected shard count is mandatory: without it the completeness check
   // below would be skipped and any subset of shards scoring >= break would pass

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -1,0 +1,128 @@
+/**
+ * CLI entry point for the sharded mutation-score gate.
+ *
+ * CI runs Stryker as N parallel shards (see `stryker.shard.config.mjs`), each
+ * emitting a `mutation-shard-<index>.json` report. This script unions those
+ * reports and re-enforces the project's real `thresholds.break` over the whole
+ * set, so the sharded run gates exactly as an unsharded `stryker run` would. The
+ * break threshold is read from `stryker.config.mjs` itself, so it can never drift
+ * from the canonical gate.
+ *
+ * It exits `0` when the merged mutation score meets the break threshold, and `1`
+ * when the score is below it, when a shard report is missing, or when no valid
+ * mutants were found (a missing/empty shard must never let the gate pass
+ * vacuously). The merge math lives in {@link ./mutation-report.ts}.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { type MutationReport, scoreReports } from './mutation-report';
+
+const SHARD_FILE = /^mutation-shard-\d+\.json$/;
+
+/** Read and parse every `mutation-shard-*.json` report in `dir`. */
+function loadShardReports(dir: string): { name: string; report: MutationReport }[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (error) {
+    throw new Error(`Could not read mutation report directory "${dir}": ${String(error)}`);
+  }
+
+  return entries
+    .filter(name => SHARD_FILE.test(name))
+    .sort()
+    .map(name => {
+      const raw = readFileSync(join(dir, name), 'utf8');
+      try {
+        return { name, report: JSON.parse(raw) as MutationReport };
+      } catch (error) {
+        throw new Error(`Mutation report "${name}" is not valid JSON: ${String(error)}`);
+      }
+    });
+}
+
+/** Read the canonical break threshold from the real Stryker config. */
+async function resolveBreakThreshold(): Promise<number> {
+  const { default: base } = (await import('../../stryker.config.mjs')) as {
+    default: { thresholds?: { break?: number | null } };
+  };
+  const breakThreshold = base.thresholds?.break;
+  if (typeof breakThreshold !== 'number') {
+    throw new Error(
+      'stryker.config.mjs does not define a numeric thresholds.break; refusing to gate without a known threshold.'
+    );
+  }
+  return breakThreshold;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] ?? 'reports/mutation';
+
+  // The expected shard count is mandatory: without it the completeness check
+  // below would be skipped and any subset of shards scoring >= break would pass
+  // vacuously. CI and the Makefile always set MUTATION_SHARD_TOTAL.
+  const expectedShards = Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '', 10);
+  if (!Number.isInteger(expectedShards) || expectedShards <= 0) {
+    throw new Error(
+      'MUTATION_SHARD_TOTAL must be a positive integer so the gate can verify every shard is present.'
+    );
+  }
+
+  const shards = loadShardReports(dir);
+  if (shards.length !== expectedShards) {
+    throw new Error(
+      `Expected ${expectedShards} shard reports but found ${shards.length} (${
+        shards.map(s => s.name).join(', ') || 'none'
+      }). A missing shard must not pass the gate vacuously.`
+    );
+  }
+
+  // Verify the indices are exactly {0 .. expectedShards-1}: count alone could be
+  // satisfied by duplicates while a real shard is missing.
+  const seen = new Set(shards.map(s => Number.parseInt(/\d+/.exec(s.name)?.[0] ?? '-1', 10)));
+  for (let i = 0; i < expectedShards; i += 1) {
+    if (!seen.has(i)) {
+      throw new Error(`Mutation shard ${i} of ${expectedShards} is missing from "${dir}".`);
+    }
+  }
+
+  const breakThreshold = await resolveBreakThreshold();
+  const { tally, fileCount, mutationScore } = scoreReports(shards.map(s => s.report));
+
+  if (!Number.isFinite(mutationScore) || tally.valid === 0) {
+    throw new Error(
+      `No valid mutants found across ${shards.length} shard(s) over ${fileCount} file(s); ` +
+        'the mutation run is misconfigured.'
+    );
+  }
+
+  const score = mutationScore.toFixed(2);
+  process.stdout.write(
+    [
+      `Merged ${shards.length} mutation shard(s) over ${fileCount} source file(s):`,
+      `  killed=${tally.killed} timeout=${tally.timeout} ` +
+        `survived=${tally.survived} noCoverage=${tally.noCoverage} ` +
+        `compileError=${tally.compileError} runtimeError=${tally.runtimeError} ignored=${tally.ignored}`,
+      `  detected=${tally.detected} valid=${tally.valid} mutationScore=${score}%`,
+      '',
+    ].join('\n')
+  );
+
+  if (mutationScore < breakThreshold) {
+    process.stderr.write(
+      `Mutation score ${score}% is below the break threshold ${breakThreshold}%. Failing the gate.\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `Mutation score ${score}% meets the break threshold ${breakThreshold}%. Gate passed.\n`
+  );
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/ci/mutation-report.ts
+++ b/scripts/ci/mutation-report.ts
@@ -76,6 +76,17 @@ export function mergeReportFiles(reports: readonly MutationReport[]): Map<string
   return byFile;
 }
 
+/** Map each Stryker mutant status to its tally counter. */
+const STATUS_TALLY_KEYS = new Map<string, keyof StatusTally>([
+  ['Killed', 'killed'],
+  ['Timeout', 'timeout'],
+  ['Survived', 'survived'],
+  ['NoCoverage', 'noCoverage'],
+  ['CompileError', 'compileError'],
+  ['RuntimeError', 'runtimeError'],
+  ['Ignored', 'ignored'],
+]);
+
 /** Tally mutant statuses across the merged source files. */
 export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>): StatusTally {
   const tally: StatusTally = {
@@ -94,32 +105,12 @@ export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>)
 
   for (const mutants of mutantsByFile.values()) {
     for (const mutant of mutants) {
-      switch (mutant.status) {
-        case 'Killed':
-          tally.killed += 1;
-          break;
-        case 'Timeout':
-          tally.timeout += 1;
-          break;
-        case 'Survived':
-          tally.survived += 1;
-          break;
-        case 'NoCoverage':
-          tally.noCoverage += 1;
-          break;
-        case 'CompileError':
-          tally.compileError += 1;
-          break;
-        case 'RuntimeError':
-          tally.runtimeError += 1;
-          break;
-        case 'Ignored':
-          tally.ignored += 1;
-          break;
-        default:
-          // `Pending` or any unrecognised status: not a settled, valid result.
-          tally.pending += 1;
-          break;
+      const key = mutant.status === undefined ? undefined : STATUS_TALLY_KEYS.get(mutant.status);
+      if (key === undefined) {
+        // `Pending` or any unrecognised status: not a settled, valid result.
+        tally.pending += 1;
+      } else {
+        tally[key] += 1;
       }
     }
   }

--- a/scripts/ci/mutation-report.ts
+++ b/scripts/ci/mutation-report.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure helpers for merging Stryker shard reports and computing the mutation-score
+ * gate exactly as Stryker does, so that a sharded CI run enforces the identical
+ * `thresholds.break` an unsharded `stryker run` would.
+ *
+ * Stryker breaks the build when `systemUnderTestMetrics.metrics.mutationScore` is
+ * below `thresholds.break` (see `@stryker-mutator/core`
+ * `reporters/mutation-test-report-helper.ts#determineExitCode`). That score, per
+ * `mutation-testing-metrics`, is computed only from the *source* files (the report
+ * `files` map — `testFiles` are excluded) as:
+ *
+ *   detected   = killed + timeout
+ *   undetected = survived + noCoverage
+ *   valid      = detected + undetected
+ *   mutationScore = valid > 0 ? (detected / valid) * 100 : NaN
+ *
+ * Invalid mutants (compile/runtime errors) and ignored mutants are excluded from
+ * both numerator and denominator. Sharding by source file is score-preserving:
+ * every mutant is run against the full test suite regardless of which shard owns
+ * its file, so the union of disjoint shards equals one unsharded run.
+ */
+
+/** A single mutant entry in a `mutation-testing-elements` JSON report. */
+export interface ReportMutant {
+  status?: string;
+}
+
+/** A source file entry (the system under test) in a mutation report. */
+export interface ReportFile {
+  mutants?: ReportMutant[];
+}
+
+/** The subset of the `mutation-testing-elements` schema this gate reads. */
+export interface MutationReport {
+  files?: Record<string, ReportFile>;
+}
+
+/** Per-status mutant counts plus the derived detected/undetected/valid totals. */
+export interface StatusTally {
+  killed: number;
+  timeout: number;
+  survived: number;
+  noCoverage: number;
+  compileError: number;
+  runtimeError: number;
+  ignored: number;
+  pending: number;
+  detected: number;
+  undetected: number;
+  valid: number;
+}
+
+/** The merged score over a set of shard reports. */
+export interface ScoreResult {
+  tally: StatusTally;
+  /** Number of distinct source files contributing mutants. */
+  fileCount: number;
+  /** The overall mutation score, or `NaN` when there are no valid mutants. */
+  mutationScore: number;
+}
+
+/**
+ * Union the `files` maps of every shard report, keyed by source path. Shards are
+ * disjoint by construction; if the same path somehow appears twice the first
+ * occurrence wins, which keeps mutants from being double-counted.
+ */
+export function mergeReportFiles(reports: readonly MutationReport[]): Map<string, ReportMutant[]> {
+  const byFile = new Map<string, ReportMutant[]>();
+  for (const report of reports) {
+    for (const [path, file] of Object.entries(report.files ?? {})) {
+      if (!byFile.has(path)) {
+        byFile.set(path, file?.mutants ?? []);
+      }
+    }
+  }
+  return byFile;
+}
+
+/** Tally mutant statuses across the merged source files. */
+export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>): StatusTally {
+  const tally: StatusTally = {
+    killed: 0,
+    timeout: 0,
+    survived: 0,
+    noCoverage: 0,
+    compileError: 0,
+    runtimeError: 0,
+    ignored: 0,
+    pending: 0,
+    detected: 0,
+    undetected: 0,
+    valid: 0,
+  };
+
+  for (const mutants of mutantsByFile.values()) {
+    for (const mutant of mutants) {
+      switch (mutant.status) {
+        case 'Killed':
+          tally.killed += 1;
+          break;
+        case 'Timeout':
+          tally.timeout += 1;
+          break;
+        case 'Survived':
+          tally.survived += 1;
+          break;
+        case 'NoCoverage':
+          tally.noCoverage += 1;
+          break;
+        case 'CompileError':
+          tally.compileError += 1;
+          break;
+        case 'RuntimeError':
+          tally.runtimeError += 1;
+          break;
+        case 'Ignored':
+          tally.ignored += 1;
+          break;
+        default:
+          // `Pending` or any unrecognised status: not a settled, valid result.
+          tally.pending += 1;
+          break;
+      }
+    }
+  }
+
+  tally.detected = tally.killed + tally.timeout;
+  tally.undetected = tally.survived + tally.noCoverage;
+  tally.valid = tally.detected + tally.undetected;
+  return tally;
+}
+
+/** The overall mutation score for a tally, or `NaN` when no valid mutants exist. */
+export function mutationScore(tally: StatusTally): number {
+  return tally.valid > 0 ? (tally.detected / tally.valid) * 100 : Number.NaN;
+}
+
+/** Merge shard reports and compute the overall mutation score. */
+export function scoreReports(reports: readonly MutationReport[]): ScoreResult {
+  const byFile = mergeReportFiles(reports);
+  const tally = tallyMutants(byFile);
+  return { tally, fileCount: byFile.size, mutationScore: mutationScore(tally) };
+}

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -15,6 +15,9 @@ const config = {
     configFile: 'jest.mutation.config.ts',
     enableFindRelatedTests: false,
   },
+  // If you change this set, update stryker.shard.config.mjs's collectTsxFiles walk
+  // to match: the sharded CI gate derives its file set independently, and a drift
+  // here would silently drop mutants from the merged score (a hidden gate weaken).
   mutate: ['./src/components/**/*.tsx', '!./src/components/**/*.stories.tsx'],
   // Keep the Stryker sandbox copy from choking on non-source dirs (the `.qlty`
   // log dir in particular triggers an EISDIR copyfile error).

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import base from './stryker.config.mjs';
+
+// CI runs mutation testing as MUTATION_SHARD_TOTAL parallel shards; this config
+// mutates only shard MUTATION_SHARD_INDEX's deterministic slice of the file set.
+const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
+const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
+
+// Walk the same source the base `mutate` selects (src/components/**/*.tsx, minus
+// stories) so a shard can never mutate a different set than an unsharded run.
+function collectTsxFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectTsxFiles(full);
+    if (entry.name.endsWith('.tsx') && !entry.name.endsWith('.stories.tsx')) return [full];
+    return [];
+  });
+}
+
+// Round-robin assignment keeps shards disjoint and balanced. Sharding by file is
+// mutation-score-preserving: each mutant runs against the full suite regardless
+// of which shard owns its file, so the union of disjoint shards equals one full
+// run. scripts/ci/merge-mutation-reports.ts re-enforces the real break gate over
+// that union.
+const sliced = collectTsxFiles('src/components')
+  .sort()
+  .filter((_, i) => i % total === index % total);
+
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  ...base,
+  // Match the canonical run's concurrency exactly. A higher value could, under
+  // CPU contention, turn a would-be Survived mutant into a Timeout (counted as
+  // detected) and inflate the merged score — a non-score-preserving leniency the
+  // gate must not introduce. Speed comes from sharding across runners, not from
+  // raising per-shard concurrency.
+  concurrency: base.concurrency,
+  mutate: sliced,
+  reporters: ['json', 'clear-text', 'progress'],
+  jsonReporter: { fileName: `reports/mutation/mutation-shard-${index}.json` },
+  // A shard must never gate on its own partial slice. The real high:90 / break:80
+  // gate (stryker.config.mjs) is re-enforced once, over the union of all shards,
+  // by scripts/ci/merge-mutation-reports.ts. This is not a threshold change.
+  thresholds: { ...base.thresholds, break: null },
+};
+
+export default config;

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -11,7 +11,7 @@ install	bats	tests/bats/makefile_targets.bats	Validated as the Bun dependency in
 lighthouse-desktop	bats	tests/bats/makefile_targets.bats	Validated as the desktop Lighthouse shell entrypoint.
 lighthouse-mobile	bats	tests/bats/makefile_targets.bats	Validated as the mobile Lighthouse shell entrypoint.
 lint	ci	.github/workflows/static-testing.yml	Executed indirectly through the static testing workflow's individual lint targets.
-lint-dep-cruiser	ci	.github/workflows/dependency-cruiser.yml	Executed directly by the dedicated dependency-cruiser pull-request workflow.
+lint-deps	ci	.github/workflows/dependency-cruiser.yml	Executed directly by the dedicated dependency-cruiser pull-request workflow.
 lint-md	ci	.github/workflows/static-testing.yml	Executed directly by the static testing workflow.
 lint-next	ci	.github/workflows/static-testing.yml	Executed directly by the static testing workflow.
 lint-tsc	ci	.github/workflows/static-testing.yml	Executed directly by the static testing workflow.

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -40,3 +40,8 @@ update	bats	tests/bats/makefile_targets.bats	Validated as the Bun dependency upd
 test-integration	bats	tests/bats/makefile_targets.bats	Validated for both the running-container and fresh-container branches.
 lint-metrics	bats	tests/bats/lint_metrics_make_targets.bats	Validated as the Docker-backed rca container dispatch target for the metrics gate.
 lint-metrics-run	bats	tests/bats/lint_metrics_make_targets.bats	Validated that the recipe exports RCA_BIN, RCA_SCOPE, METRICS_POLICY and runs lint-metrics.sh.
+start-bun	bats	tests/bats/makefile_targets.bats	Validated as the Bun-only Docker Compose start target for fast bun jobs.
+test-mutation-shard	bats	tests/bats/makefile_targets.bats	Validated for the running-container and fresh-container branches of the mutation shard run.
+copy-mutation-report	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the copy-success branch.
+stage-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the host-to-container copy branch.
+merge-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated for the running-container and fresh-container branches of the merge gate.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -147,3 +147,73 @@ EOF
   assert_log_contains 'docker compose exec -T bun test -d /app/coverage'
   assert_log_contains 'docker compose cp bun:/app/coverage ./coverage'
 }
+
+@test "start-bun builds and starts only the bun service" {
+  reset_command_log
+  run_make_target start-bun
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose up -d --build bun'
+}
+
+@test "test-mutation-shard prefers docker compose exec when the bun service is running" {
+  reset_command_log
+  run_make_target_with_env test-mutation-shard FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose ps -q bun'
+  assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_INDEX=0 -e MUTATION_SHARD_TOTAL=1 bun bun x stryker run stryker.shard.config.mjs'
+  assert_log_not_contains 'docker compose run --rm'
+}
+
+@test "test-mutation-shard falls back to docker compose run when the bun service is not running" {
+  reset_command_log
+  run_make_target test-mutation-shard
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose run --rm -e MUTATION_SHARD_INDEX=0 -e MUTATION_SHARD_TOTAL=1 bun bun x stryker run stryker.shard.config.mjs'
+  assert_log_not_contains 'docker compose exec -T'
+}
+
+@test "copy-mutation-report fails clearly when the bun service is not running" {
+  reset_command_log
+  run_make_target copy-mutation-report
+  [ "$status" -ne 0 ]
+  assert_output_contains 'bun service is not running; start docker before copying the report'
+  assert_log_contains 'docker compose ps -q bun'
+}
+
+@test "copy-mutation-report copies the shard report when the bun service is running" {
+  reset_command_log
+  run_make_target_with_env copy-mutation-report FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose cp bun:/app/reports/mutation/mutation-shard-0.json reports/mutation/mutation-shard-0.json'
+}
+
+@test "stage-mutation-reports fails clearly when the bun service is not running" {
+  reset_command_log
+  run_make_target stage-mutation-reports
+  [ "$status" -ne 0 ]
+  assert_output_contains 'bun service is not running; start docker before staging reports'
+}
+
+@test "stage-mutation-reports copies host reports into the bun container when it is running" {
+  reset_command_log
+  run_make_target_with_env stage-mutation-reports FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose exec -T bun mkdir -p reports/mutation'
+  assert_log_contains 'docker compose cp reports/mutation/. bun:/app/reports/mutation'
+}
+
+@test "merge-mutation-reports prefers docker compose exec when the bun service is running" {
+  reset_command_log
+  run_make_target_with_env merge-mutation-reports FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts reports/mutation'
+  assert_log_not_contains 'docker compose run --rm'
+}
+
+@test "merge-mutation-reports falls back to docker compose run when the bun service is not running" {
+  reset_command_log
+  run_make_target merge-mutation-reports
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose run --rm -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts reports/mutation'
+  assert_log_not_contains 'docker compose exec -T'
+}

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -153,9 +153,11 @@ EOF
   run_make_target start-bun
   [ "$status" -eq 0 ]
   assert_log_contains 'docker compose up -d --build bun'
+  assert_log_not_contains 'storybook'
+  assert_log_not_contains 'playwright'
 }
 
-@test "test-mutation-shard prefers docker compose exec when the bun service is running" {
+@test "test-mutation-shard runs in the running bun container via docker compose exec" {
   reset_command_log
   run_make_target_with_env test-mutation-shard FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
   [ "$status" -eq 0 ]
@@ -164,12 +166,12 @@ EOF
   assert_log_not_contains 'docker compose run --rm'
 }
 
-@test "test-mutation-shard falls back to docker compose run when the bun service is not running" {
+@test "test-mutation-shard fails clearly when the bun service is not running" {
   reset_command_log
   run_make_target test-mutation-shard
-  [ "$status" -eq 0 ]
-  assert_log_contains 'docker compose run --rm -e MUTATION_SHARD_INDEX=0 -e MUTATION_SHARD_TOTAL=1 bun bun x stryker run stryker.shard.config.mjs'
-  assert_log_not_contains 'docker compose exec -T'
+  [ "$status" -ne 0 ]
+  assert_output_contains 'bun service is not running'
+  assert_log_not_contains 'docker compose run --rm'
 }
 
 @test "copy-mutation-report fails clearly when the bun service is not running" {
@@ -202,7 +204,7 @@ EOF
   assert_log_contains 'docker compose cp reports/mutation/. bun:/app/reports/mutation'
 }
 
-@test "merge-mutation-reports prefers docker compose exec when the bun service is running" {
+@test "merge-mutation-reports runs in the running bun container via docker compose exec" {
   reset_command_log
   run_make_target_with_env merge-mutation-reports FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
   [ "$status" -eq 0 ]
@@ -210,10 +212,10 @@ EOF
   assert_log_not_contains 'docker compose run --rm'
 }
 
-@test "merge-mutation-reports falls back to docker compose run when the bun service is not running" {
+@test "merge-mutation-reports fails clearly when the bun service is not running" {
   reset_command_log
   run_make_target merge-mutation-reports
-  [ "$status" -eq 0 ]
-  assert_log_contains 'docker compose run --rm -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts'
+  [ "$status" -ne 0 ]
+  assert_output_contains 'bun service is not running'
   assert_log_not_contains 'docker compose exec -T'
 }

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -206,7 +206,7 @@ EOF
   reset_command_log
   run_make_target_with_env merge-mutation-reports FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
   [ "$status" -eq 0 ]
-  assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts reports/mutation'
+  assert_log_contains 'docker compose exec -T -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts'
   assert_log_not_contains 'docker compose run --rm'
 }
 
@@ -214,6 +214,6 @@ EOF
   reset_command_log
   run_make_target merge-mutation-reports
   [ "$status" -eq 0 ]
-  assert_log_contains 'docker compose run --rm -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts reports/mutation'
+  assert_log_contains 'docker compose run --rm -e MUTATION_SHARD_TOTAL=1 bun bun scripts/ci/merge-mutation-reports.ts'
   assert_log_not_contains 'docker compose exec -T'
 }

--- a/tests/unit/mutation-report.test.ts
+++ b/tests/unit/mutation-report.test.ts
@@ -1,0 +1,107 @@
+import {
+  type MutationReport,
+  mergeReportFiles,
+  mutationScore,
+  scoreReports,
+  tallyMutants,
+} from '../../scripts/ci/mutation-report';
+
+/** Build a minimal mutation-testing-elements report from per-file status lists. */
+function report(files: Record<string, string[]>): MutationReport {
+  return {
+    files: Object.fromEntries(
+      Object.entries(files).map(([path, statuses]) => [
+        path,
+        { mutants: statuses.map(status => ({ status })) },
+      ])
+    ),
+  };
+}
+
+describe('mutation-report merge gate', () => {
+  describe('mutationScore mirrors Stryker (detected / valid * 100)', () => {
+    it('counts killed and timeout as detected', () => {
+      const tally = tallyMutants(mergeReportFiles([report({ 'a.tsx': ['Killed', 'Timeout'] })]));
+      expect(tally.detected).toBe(2);
+      expect(tally.valid).toBe(2);
+      expect(mutationScore(tally)).toBe(100);
+    });
+
+    it('counts survived and noCoverage against the score (undetected, still valid)', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([report({ 'a.tsx': ['Killed', 'Killed', 'Survived', 'NoCoverage'] })])
+      );
+      expect(tally.detected).toBe(2);
+      expect(tally.undetected).toBe(2);
+      expect(tally.valid).toBe(4);
+      expect(mutationScore(tally)).toBe(50);
+    });
+
+    it('excludes compile/runtime errors and ignored mutants from valid', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([
+          report({ 'a.tsx': ['Killed', 'CompileError', 'RuntimeError', 'Ignored'] }),
+        ])
+      );
+      expect(tally.compileError).toBe(1);
+      expect(tally.runtimeError).toBe(1);
+      expect(tally.ignored).toBe(1);
+      // Only the single Killed mutant is valid -> 1/1 = 100%.
+      expect(tally.valid).toBe(1);
+      expect(mutationScore(tally)).toBe(100);
+    });
+
+    it('treats Pending and unknown statuses as non-valid', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([report({ 'a.tsx': ['Killed', 'Pending', 'Weird'] })])
+      );
+      expect(tally.pending).toBe(2);
+      expect(tally.valid).toBe(1);
+    });
+
+    it('returns NaN when there are no valid mutants', () => {
+      const tally = tallyMutants(mergeReportFiles([report({ 'a.tsx': ['Ignored'] })]));
+      expect(tally.valid).toBe(0);
+      expect(Number.isNaN(mutationScore(tally))).toBe(true);
+    });
+  });
+
+  describe('the 80% break boundary is exact', () => {
+    it('scores 80% when 8 of 10 valid mutants are detected', () => {
+      const statuses = [...Array(8).fill('Killed'), 'Survived', 'NoCoverage'];
+      expect(scoreReports([report({ 'a.tsx': statuses })]).mutationScore).toBe(80);
+    });
+
+    it('scores below 80% when only 7 of 10 are detected', () => {
+      const statuses = [...Array(7).fill('Killed'), ...Array(3).fill('Survived')];
+      expect(scoreReports([report({ 'a.tsx': statuses })]).mutationScore).toBeCloseTo(70, 10);
+    });
+  });
+
+  describe('merging shard reports', () => {
+    it('unions disjoint files and sums their mutants', () => {
+      const result = scoreReports([
+        report({ 'a.tsx': ['Killed', 'Killed'] }),
+        report({ 'b.tsx': ['Killed', 'Survived'] }),
+      ]);
+      expect(result.fileCount).toBe(2);
+      expect(result.tally.detected).toBe(3);
+      expect(result.tally.valid).toBe(4);
+      expect(result.mutationScore).toBe(75);
+    });
+
+    it('does not double-count a file that appears in two shards', () => {
+      const duplicate = report({ 'a.tsx': ['Killed', 'Survived'] });
+      const result = scoreReports([duplicate, duplicate]);
+      expect(result.fileCount).toBe(1);
+      expect(result.tally.valid).toBe(2);
+      expect(result.mutationScore).toBe(50);
+    });
+
+    it('tolerates reports with no files', () => {
+      const result = scoreReports([{}, report({ 'a.tsx': ['Killed'] })]);
+      expect(result.fileCount).toBe(1);
+      expect(result.mutationScore).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #64. Makes CI fast by **parallelizing in place** — every gate still runs on every PR (no
nightly tier, no threshold changed). GitHub already runs the workflows in parallel, so PR wall-clock
is the single slowest job, which was **mutation testing (~1h)**.

## Changes

- **Mutation testing → 4-way shard matrix + fail-closed merge gate.** Each shard mutates a
  deterministic, disjoint slice of the same `src/components/**/*.tsx` set (`stryker.shard.config.mjs`)
  and uploads a per-shard JSON report. A `merge and enforce gate` job unions them and re-enforces the
  **unchanged** `break:80` read live from `stryker.config.mjs`
  (`scripts/ci/merge-mutation-reports.ts`). Sharding by file is score-preserving; per-shard
  `concurrency` is pinned to the base value so timeout behavior matches an unsharded run. Expected:
  **~1h → ~15 min.**
- **`concurrency: cancel-in-progress` on every workflow** (`false` on `autorelease`/`autoprerelease`
  so a release is never aborted) — superseded pushes are cancelled.
- **Lighthouse desktop/mobile split into a parallel matrix** (was sequential in one job).
- **Bun-only jobs use `make start-bun`** — skips the Storybook/Playwright image builds they don't need.

## Gate safety (no weakening)

- The merge job runs `if: ${{ !cancelled() }}` with a guard that fails when any shard fails — a
  *skipped* required check would otherwise count as a pass and silently bypass the gate.
- The merge requires `MUTATION_SHARD_TOTAL` and verifies shard indices form `{0..N-1}`, so a dropped
  shard fails closed instead of passing vacuously.
- Merge score math mirrors Stryker exactly (`detected/valid*100`; `noCoverage` counts against;
  compile/runtime/ignored excluded; `testFiles` excluded) — unit-tested in
  `tests/unit/mutation-report.test.ts`.

## Verification

tsc · 336 unit tests @ 100% coverage · CLI smokes (pass/fail/missing-shard/bad-total/boundary) ·
**real Docker shard→copy→stage→merge** (pass + fail-closed) · prettier · eslint · markdownlint ·
actionlint (all 19 workflows) · **46 bats** incl. the `make-target-coverage` contract (5 new targets
registered).

## Maintainer action required

Branch protection must require **`merge and enforce gate`**, **`lighthouse desktop`**, and
**`lighthouse mobile`** (the old single `mutation-testing` / `performance` checks no longer exist).
The merge job fails closed, so requiring it alone is sufficient. See the new "CI speed and the
mutation-testing gate" section in `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized CI by sharding mutation testing and running Lighthouse in a matrix to cut PR wall‑clock from ~1h to ~15m without weakening any gates. Addresses #64 with the same `break:80` threshold enforced via a fail‑closed merge gate.

- **Refactors**
  - Sharded Stryker into a 4‑way matrix; each shard runs in the running `bun` service, uploads a JSON report, and a final `merge and enforce gate` job unions them and enforces `break:80` read from `stryker.config.mjs` (fails closed if any shard fails or is missing). The merge gate reads from fixed `reports/mutation`, sorts files deterministically, strictly checks the numeric threshold, uses leaner tally logic, passes shard results via env; actions in mutation/perf workflows are pinned and mutation checkouts set `persist-credentials: false`.
  - Added `concurrency: cancel-in-progress` to all workflows (disabled for `autoprerelease`/`autorelease`), split Lighthouse into a `desktop`/`mobile` matrix that runs without a long‑lived service, and made Bun‑only jobs use `make start-bun`. Renamed `make lint-dep-cruiser` to `make lint-deps` and updated the workflow and docs.

- **Migration**
  - Update required status checks to: “merge and enforce gate”, “lighthouse desktop”, and “lighthouse mobile” (replace the old single mutation/performance checks).

<sup>Written for commit 18cd759d6c76d578c77ba1885ac48c36971fb18d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

