### PR TITLE
fix(#74): graceful degradation on nullish UiImage src / UiCardList cardList

### DIFF
--- a/Dockerfile.rca
+++ b/Dockerfile.rca
@@ -14,7 +14,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
       ca-certificates=20230311+deb12u1 \
       curl=7.88.1-10+deb12u14 \
-      jq=1.6-2.1+deb12u1 \
+      jq=1.6-2.1+deb12u2 \
       make=4.3-4.1 \
       tar=1.34+dfsg-1.2+deb12u1; \
     rm -rf /var/lib/apt/lists/*; \

--- a/src/components/ui-card-item/services-hover-card/services-hover-card.tsx
+++ b/src/components/ui-card-item/services-hover-card/services-hover-card.tsx
@@ -21,6 +21,9 @@ function ServicesHoverCard(): React.ReactElement {
         {t('unlimited_possibilities.service_text.text')}
       </UiTypography>
       <Box sx={styles.listWrapper}>
+        {/* imageList is an internal ../constants import, never consumer-supplied,
+            so no nullish guard is needed here (unlike UiImage.src /
+            UiCardList.cardList). */}
         {imageList.map(item => (
           <ImageItem item={item} key={item.alt} />
         ))}

--- a/src/components/ui-card-list/card-swiper.tsx
+++ b/src/components/ui-card-list/card-swiper.tsx
@@ -82,7 +82,9 @@ export default function CardSwiper({
         modules={[Pagination]}
         spaceBetween={12}
         slidesPerView={1.04}
-        loop
+        // Looping is meaningless with 0-1 slides and makes Swiper log a warning
+        // on every mount; only enable it once there is more than one card to wrap.
+        loop={cardList.length > 1}
       >
         {cardList.map(item => (
           <SwiperSlide key={item.id}>

--- a/src/components/ui-card-list/index.tsx
+++ b/src/components/ui-card-list/index.tsx
@@ -1,22 +1,33 @@
 import { Box, useMediaQuery } from '@mui/material';
 import React from 'react';
 
+import { useDevWarning } from '@/utils/dev-warn';
+
 import breakpointsTheme from '../ui-breakpoints';
 
 import CardGrid from './card-grid';
 import CardSwiper from './card-swiper';
 import styles from './styles';
-import type { UiCardListProps } from './types';
+import type { UiCardItemData, UiCardListProps } from './types';
 
 // Shared card styling owned by the card-list module; UiCardItem consumes it
 // through this public entry rather than reaching into ./shared-card-styles
 // (components-public-api boundary rule).
 export * from './shared-card-styles';
 
+const MISSING_CARD_LIST_WARNING: string =
+  'UiCardList received a nullish `cardList`; rendering an empty list. Pass an array of card items.';
+
 export default function UiCardList({
   cardList,
   headingComponent,
 }: UiCardListProps): React.ReactElement {
+  useDevWarning(cardList ? null : MISSING_CARD_LIST_WARNING);
+  // Normalize once at the public entry so both children keep their simple
+  // `UiCardItemData[]` contract; a nullish runtime value degrades to an empty
+  // grid/swiper instead of crashing the whole subtree on `.map`.
+  const safeCardList: UiCardItemData[] = cardList ?? [];
+
   // Render exactly one variant. Gating CardGrid on `!isSmallScreen` (rather than
   // mounting it always and hiding it with CSS) avoids rendering the whole card
   // tree twice on mobile, matching how CardSwiper is gated.
@@ -28,12 +39,12 @@ export default function UiCardList({
     <>
       <Box sx={styles.gridContainerLargeScreen}>
         {isSmallScreen ? null : (
-          <CardGrid cardList={cardList} headingComponent={headingComponent} />
+          <CardGrid cardList={safeCardList} headingComponent={headingComponent} />
         )}
       </Box>
       <Box sx={styles.swiperContainerSmallScreen}>
         {isSmallScreen ? (
-          <CardSwiper cardList={cardList} headingComponent={headingComponent} />
+          <CardSwiper cardList={safeCardList} headingComponent={headingComponent} />
         ) : null}
       </Box>
     </>

--- a/src/components/ui-card-list/types.ts
+++ b/src/components/ui-card-list/types.ts
@@ -20,6 +20,12 @@ export type UiCardItemData = {
 };
 
 export interface UiCardListProps {
+  /**
+   * Cards to render. The type is strict, but the component degrades gracefully
+   * on runtime data: a nullish `cardList` is normalized to an empty list — the
+   * grid/swiper mounts with no cards instead of crashing on `.map` — and logs a
+   * development-only `console.warn`.
+   */
   cardList: UiCardItemData[];
   /**
    * Overrides the rendered heading element of every card title so consumers can

--- a/src/components/ui-footer/default-footer/default-footer.tsx
+++ b/src/components/ui-footer/default-footer/default-footer.tsx
@@ -51,6 +51,9 @@ function FooterBottomBar({
           <Stack direction="row" sx={{ gap: '0.875rem', alignItems: 'center' }}>
             <VilnaCRMEmail />
             <Stack direction="row" sx={{ ...styles.listWrapper, alignItems: 'center' }}>
+              {/* socialLinks is sourced from the propless UiFooter's internal
+                  ./constants, never from consumer input, so no nullish guard is
+                  needed here (unlike UiImage.src / UiCardList.cardList). */}
               {socialLinks.map(item => (
                 <SocialMediaItem item={item} key={item.id} />
               ))}

--- a/src/components/ui-footer/mobile/mobile.tsx
+++ b/src/components/ui-footer/mobile/mobile.tsx
@@ -18,6 +18,9 @@ function SocialLinksRow({
 }: Readonly<{ socialLinks: SocialMedia[] }>): React.ReactElement {
   return (
     <Stack direction="row" sx={{ ...styles.listWrapper, alignItems: 'center' }}>
+      {/* socialLinks is sourced from the propless UiFooter's internal ./constants,
+          never from consumer input, so no nullish guard is needed here (unlike the
+          consumer-facing UiImage.src / UiCardList.cardList props). */}
       {socialLinks.map(item => (
         <SocialMediaItem item={item} key={item.id} />
       ))}

--- a/src/components/ui-image/index.tsx
+++ b/src/components/ui-image/index.tsx
@@ -1,11 +1,21 @@
 import { Box, SxProps, Theme } from '@mui/material';
 import React from 'react';
 
+import { useDevWarning } from '@/utils/dev-warn';
+
 import styles from './styles';
 import type { UiImageProps } from './types';
 
+const MISSING_SRC_WARNING: string =
+  'UiImage received a nullish `src`; rendering an empty wrapper. Pass a valid URL or import.';
+
 function UiImage({ sx, alt, src }: UiImageProps): React.ReactElement {
-  const imageUrl: string = typeof src === 'string' ? src : src.src;
+  // `src?.src` also absorbs a `null` object (typeof null === 'object', so the
+  // else-branch would otherwise read `.src` off null and throw) — the guard is
+  // for runtime data the strict prop type forbids, not the happy path.
+  const imageUrl: string | undefined = typeof src === 'string' ? src : src?.src;
+  useDevWarning(imageUrl ? null : MISSING_SRC_WARNING);
+
   const mergedSx: SxProps<Theme> = Array.isArray(sx)
     ? [styles.wrapper, ...sx]
     : sx
@@ -13,9 +23,7 @@ function UiImage({ sx, alt, src }: UiImageProps): React.ReactElement {
       : [styles.wrapper];
 
   return (
-    <Box sx={mergedSx}>
-      <img alt={alt} src={imageUrl} loading="lazy" />
-    </Box>
+    <Box sx={mergedSx}>{imageUrl ? <img alt={alt} src={imageUrl} loading="lazy" /> : null}</Box>
   );
 }
 

--- a/src/components/ui-image/types.ts
+++ b/src/components/ui-image/types.ts
@@ -2,6 +2,13 @@ import type { SxProps, Theme } from '@mui/material';
 
 export interface UiImageProps {
   sx?: SxProps<Theme>;
+  /**
+   * Image source — a URL string or a static import (`{ src }`). The type is
+   * strict, but the component degrades gracefully on runtime data: a nullish
+   * `src` (or a nullish resolved URL) renders the styled wrapper with **no**
+   * `<img>` and logs a development-only `console.warn`. No image is emitted, so
+   * no alternative text is owed for the missing content.
+   */
   src: { src: string } | string;
   alt: string;
 }

--- a/src/utils/dev-warn.ts
+++ b/src/utils/dev-warn.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+/**
+ * Emits a `console.warn` in development only; stripped from the production build
+ * so the published bundle stays silent. Shared by the exported components that
+ * degrade gracefully on runtime-invalid props the strict TypeScript types forbid
+ * (e.g. CMS/API data feeding a nullish value into a required prop).
+ */
+export function devWarn(message: string): void {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+  console.warn(message);
+}
+
+/**
+ * Runs {@link devWarn} from an effect keyed to `message`, so a normal re-render
+ * does not re-log while a prop change into or out of the warning state does.
+ * Pass `null` when there is nothing to warn about.
+ */
+export function useDevWarning(message: string | null): void {
+  useEffect((): void => {
+    if (message != null) {
+      devWarn(message);
+    }
+  }, [message]);
+}

--- a/tests/integration/components/ui-card-list.integration.test.tsx
+++ b/tests/integration/components/ui-card-list.integration.test.tsx
@@ -227,3 +227,37 @@ describe('UiCardList grid content edge cases', () => {
     expect(screen.getByText('Custom node body')).toBeInTheDocument();
   });
 });
+
+describe('UiCardList nullish cardList degradation (real children)', () => {
+  // A nullish runtime value (CMS/API data) that the strict type forbids must
+  // degrade to an empty grid/swiper through the real composed chain, not crash.
+  const nullishCardList: UiCardItemData[] = undefined as unknown as UiCardItemData[];
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach((): void => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation((): void => undefined);
+  });
+
+  afterEach((): void => {
+    warnSpy.mockRestore();
+  });
+
+  it('renders an empty grid and dev-warns when cardList is nullish', () => {
+    setLargeScreen();
+
+    render(<UiCardList cardList={nullishCardList} />);
+
+    expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('img', HIDDEN)).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('nullish'));
+  });
+
+  it('renders an empty swiper when cardList is nullish', () => {
+    setSmallScreen();
+
+    render(<UiCardList cardList={nullishCardList} />);
+
+    expect(screen.getByTestId('swiper')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('swiper-slide')).toHaveLength(0);
+  });
+});

--- a/tests/unit/dev-warn.test.ts
+++ b/tests/unit/dev-warn.test.ts
@@ -1,0 +1,33 @@
+import { devWarn } from '../../src/utils/dev-warn';
+
+// `useDevWarning` (the effect wrapper) is exercised end to end by the component
+// suites that consume it (ui-image, ui-card-list); here we pin the shared
+// primitive's own contract: log in development, stay silent in production.
+describe('devWarn', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach((): void => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation((): void => undefined);
+  });
+
+  afterEach((): void => {
+    warnSpy.mockRestore();
+  });
+
+  it('logs the message via console.warn in development', () => {
+    devWarn('example warning');
+
+    expect(warnSpy).toHaveBeenCalledWith('example warning');
+  });
+
+  it('emits nothing in production', () => {
+    const originalEnv: string | undefined = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      devWarn('example warning');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+});

--- a/tests/unit/ui-card-list.test.tsx
+++ b/tests/unit/ui-card-list.test.tsx
@@ -3,9 +3,12 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import UiCardList from '../../src/components/ui-card-list';
+import CardGrid from '../../src/components/ui-card-list/card-grid';
 import CardSwiper from '../../src/components/ui-card-list/card-swiper';
+import type { UiCardItemData } from '../../src/components/ui-card-list/types';
 
 import { cardList } from './constants';
+import mockConsoleWarn from './utils/mock-console-warn';
 
 jest.mock('@mui/material', () => ({
   ...jest.requireActual('@mui/material'),
@@ -89,5 +92,60 @@ describe('UiCardList media query argument', () => {
     render(React.createElement(UiCardList, { cardList }));
 
     expect(mockedUseMediaQuery).not.toHaveBeenCalledWith('');
+  });
+});
+
+describe('UiCardList nullish cardList degradation', () => {
+  const warn = mockConsoleWarn();
+  const mockedUseMediaQuery: jest.Mock = useMediaQuery as jest.Mock;
+  const mockedCardGrid: jest.Mock = CardGrid as jest.Mock;
+  const mockedCardSwiper: jest.Mock = CardSwiper as jest.Mock;
+
+  // The strict `cardList` type forbids nullish values, but runtime data can
+  // supply one; the entry must normalize it to [] so neither child crashes.
+  const nullishCardList: UiCardItemData[] = undefined as unknown as UiCardItemData[];
+
+  afterEach((): void => {
+    jest.clearAllMocks();
+  });
+
+  it('normalizes a nullish cardList to an empty array for the grid branch', () => {
+    mockedUseMediaQuery.mockReturnValue(false);
+
+    render(React.createElement(UiCardList, { cardList: nullishCardList }));
+
+    expect(mockedCardGrid.mock.calls[0][0]).toEqual(expect.objectContaining({ cardList: [] }));
+  });
+
+  it('normalizes a nullish cardList to an empty array for the swiper branch', () => {
+    mockedUseMediaQuery.mockReturnValue(true);
+
+    render(React.createElement(UiCardList, { cardList: nullishCardList }));
+
+    expect(mockedCardSwiper.mock.calls[0][0]).toEqual(expect.objectContaining({ cardList: [] }));
+  });
+
+  it('forwards the real cardList unchanged to the grid when one is provided', () => {
+    mockedUseMediaQuery.mockReturnValue(false);
+
+    render(React.createElement(UiCardList, { cardList }));
+
+    expect(mockedCardGrid.mock.calls[0][0]).toEqual(expect.objectContaining({ cardList }));
+  });
+
+  it('warns in development when cardList is nullish', () => {
+    mockedUseMediaQuery.mockReturnValue(false);
+
+    render(React.createElement(UiCardList, { cardList: nullishCardList }));
+
+    expect(warn.spy).toHaveBeenCalledWith(expect.stringContaining('nullish'));
+  });
+
+  it('stays silent when a valid cardList is provided', () => {
+    mockedUseMediaQuery.mockReturnValue(false);
+
+    render(React.createElement(UiCardList, { cardList }));
+
+    expect(warn.spy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/ui-card-swiper.test.tsx
+++ b/tests/unit/ui-card-swiper.test.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 
 import CardSwiper from '../../src/components/ui-card-list/card-swiper';
 import gridStyles from '../../src/components/ui-card-list/styles';
+import type { UiCardItemData } from '../../src/components/ui-card-list/types';
 
-import { largeCardList, smallCardList } from './constants';
+import { largeCardList, smallCard, smallCardList } from './constants';
+import mockConsoleWarn from './utils/mock-console-warn';
 
 type ObserverCallback = MutationCallback;
 
@@ -225,6 +227,7 @@ jest.mock('swiper/react', () => {
       children?: React.ReactNode;
       pagination?: { clickable?: boolean };
       modules?: unknown[];
+      loop?: boolean;
     }>
   ): React.ReactElement {
     const pagination: { clickable?: boolean } | undefined = props.pagination;
@@ -237,6 +240,7 @@ jest.mock('swiper/react', () => {
         'data-pagination-has-clickable-key': String(hasClickableKey),
         'data-pagination-clickable': String(pagination?.clickable === true),
         'data-modules-count': String(Array.isArray(props.modules) ? props.modules.length : -1),
+        'data-loop': String(props.loop === true),
       },
       props.children
     );
@@ -400,5 +404,44 @@ describe('CardSwiper tooltip mutation detection', () => {
 
     querySpy.mockRestore();
     observeSpy.mockRestore();
+  });
+});
+
+describe('CardSwiper loop configuration', () => {
+  const warn = mockConsoleWarn();
+
+  // Two cards with distinct ids so the multi-item case has real wrap-around and
+  // no duplicate React keys. smallCardList/largeCardList are single-item.
+  const multiCardList: UiCardItemData[] = [smallCard, { ...smallCard, id: 'second-card-id' }];
+
+  it('disables loop for an empty list', () => {
+    render(React.createElement(CardSwiper, { cardList: [] }));
+
+    // Kills the `> 1` -> `>= 1` boundary mutant (0 >= 1 is false, so this alone
+    // does not; the single-item case below does) and the `-> true` collapse.
+    expect(screen.getByTestId('swiper')).toHaveAttribute('data-loop', 'false');
+  });
+
+  it('disables loop for a single-item list', () => {
+    render(React.createElement(CardSwiper, { cardList: smallCardList }));
+
+    // Kills `> 1` -> `>= 1` (1 >= 1 would be true) and the literal-`true` collapse.
+    expect(screen.getByTestId('swiper')).toHaveAttribute('data-loop', 'false');
+  });
+
+  it('enables loop when there is more than one card', () => {
+    render(React.createElement(CardSwiper, { cardList: multiCardList }));
+
+    // Kills `> 1` -> `< 1` and the literal-`false` collapse.
+    expect(screen.getByTestId('swiper')).toHaveAttribute('data-loop', 'true');
+  });
+
+  it('emits no Swiper loop warning for a single-item list', () => {
+    // With loop disabled, real Swiper would not log its loop warning. The stub
+    // cannot emit it, so the `data-loop='false'` assertions above are the real
+    // guarantee; this guards against the component itself warning about loop.
+    render(React.createElement(CardSwiper, { cardList: smallCardList }));
+
+    expect(warn.spy).not.toHaveBeenCalledWith(expect.stringContaining('loop'));
   });
 });

--- a/tests/unit/ui-image.test.tsx
+++ b/tests/unit/ui-image.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { UiImage } from '../../src/components';
 
 import { testImg, testText } from './constants';
+import mockConsoleWarn from './utils/mock-console-warn';
 
 function getWrapper(image: HTMLElement): HTMLElement {
   // The MUI Box wrapper renders a non-semantic <div> (role "generic") that
@@ -67,5 +68,62 @@ describe('UiImage', () => {
       height: '100%',
       objectFit: 'cover',
     });
+  });
+});
+
+describe('UiImage missing-src degradation', () => {
+  const warn: { readonly spy: jest.SpyInstance } = mockConsoleWarn();
+
+  // The strict `src` type forbids nullish values, but runtime data (a CMS/API
+  // URL still loading) can supply one; the component must degrade, not crash.
+  const nullishSrc: string = undefined as unknown as string;
+
+  it('renders the styled wrapper with no <img> when src is nullish', () => {
+    const { container } = render(<UiImage alt={testText} src={nullishSrc} />);
+
+    // The Box wrapper (a <div>) still renders; only the <img> is dropped.
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(container.firstChild).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.queryByAltText(testText)).not.toBeInTheDocument();
+  });
+
+  it('drops the <img> when an object src carries a nullish url', () => {
+    render(<UiImage alt={testText} src={{ src: undefined as unknown as string }} />);
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('warns in development when src is nullish', () => {
+    render(<UiImage alt={testText} src={nullishSrc} />);
+
+    expect(warn.spy).toHaveBeenCalledWith(expect.stringContaining('nullish'));
+  });
+
+  it('stays silent when a valid src is provided', () => {
+    render(<UiImage alt={testText} src={testImg} />);
+
+    expect(warn.spy).not.toHaveBeenCalled();
+  });
+
+  it('emits no warning in production even when src is nullish', () => {
+    const originalEnv: string | undefined = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      render(<UiImage alt={testText} src={nullishSrc} />);
+      expect(warn.spy).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it('re-warns when a valid src is later cleared to nullish', () => {
+    // The warning lives in an effect keyed to the derived state, so a
+    // valid→nullish transition must re-log (guards against a mount-only cache).
+    const { rerender } = render(<UiImage alt={testText} src={testImg} />);
+    expect(warn.spy).not.toHaveBeenCalled();
+
+    rerender(<UiImage alt={testText} src={nullishSrc} />);
+    expect(warn.spy).toHaveBeenCalledWith(expect.stringContaining('nullish'));
   });
 });


### PR DESCRIPTION
## Summary

Closes #74. Several exported components threw `TypeError` on nullish runtime props (the published package is consumed by plain-JS apps and by TS apps feeding CMS/API data into props). This hardens the three call sites so bad/missing data degrades gracefully instead of crashing the consumer subtree.

- **`UiImage`** — resolve the URL via `src?.src` and render **only the styled `<Box>` wrapper (no `<img>`)** when the URL is nullish. `src?.src` also absorbs a `null` *object* (`typeof null === 'object'` used to send it down the `.src` branch and throw). With no `<img>` in the tree there is no non-text content, so no alt text is owed (WCAG 1.1.1 does not apply to absent content).
- **`UiCardList`** — normalize `cardList ?? []` **once at the public entry** so `CardGrid` and `CardSwiper` keep their simple `UiCardItemData[]` contract; a nullish list degrades to an empty grid/swiper instead of crashing on `.map`.
- **`CardSwiper`** — `loop={cardList.length > 1}` so 0–1 slides mount silently instead of Swiper logging its loop warning on every mount.

Dev-only guidance is emitted via a new shared **`src/utils/dev-warn.ts`** (`devWarn` + effect-keyed `useDevWarning`), stripped in production and mirroring the existing `ui-input` warning pattern without duplicating the guard in three places.

The three other `.map()` sites (`ui-footer` mobile/default-footer, `services-hover-card`) iterate over **internal constants reached only through propless components**, so they are documented with a note rather than guarded (guarding them would add dead branches that hurt the 100% coverage / mutation gates).

## Acceptance criteria

- [x] `render(<UiImage src={undefined as never} alt="x" />)` does not throw; asserts the wrapper renders, no `<img>`, `console.warn` fires in dev, and **stays silent in production** (`NODE_ENV=production` branch tested)
- [x] `render(<UiCardList cardList={undefined as never} />)` does not throw on **either** the grid or swiper branch (unit + integration)
- [x] Empty/single-item `CardSwiper` mounts with `loop=false` and emits no loop warning; multi-item keeps `loop=true`
- [x] Existing empty-array tests still pass unchanged
- [x] Coverage stays at the enforced **100%** (unit **and** integration); mutation score well above the 80 break threshold
- [x] JSDoc on `UiImageProps.src` and `UiCardListProps.cardList` documents the nullish-input behaviour

## Testing (host-run)

| Gate | Result |
|---|---|
| `tsc --noEmit` | ✅ clean |
| ESLint | ✅ 0 errors |
| Prettier | ✅ clean |
| Unit + coverage | ✅ 100% — 383 tests |
| Integration + coverage | ✅ 100% — 70 tests |
| dependency-cruiser | ✅ 0 errors |
| rca metrics | ✅ within all thresholds |
| Stryker (changed files) | ✅ 98.65% — `ui-image` & `ui-card-list/index.tsx` 100%; the lone survivor is the pre-existing, self-documented equivalent `[swiperRef]` effect-dep mutant in untouched code |

## Accessibility

Reviewed by the accessibility team lead + specialists (SHIP): omitting the `<img>` is the correct degraded state, an empty MUI grid/swiper introduces no empty-landmark/list issues (no roles added), and the `loop` change is a11y-neutral (a mild improvement for 0–1 items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle nullish props in the image and card list components to prevent crashes. Also bumps the RCA Docker image `jq` pin to restore successful builds. Closes #74.

- **Bug Fixes**
  - UiImage: derive URL via `src?.src`; if missing, render only the styled wrapper (no `<img>`) and emit a dev-only warning via `src/utils/dev-warn.ts`.
  - UiCardList: normalize `cardList ?? []` at the public entry; pass the safe list to `CardGrid`/`CardSwiper`; emit a dev-only warning when nullish.
  - CardSwiper: set `loop={cardList.length > 1}` to avoid Swiper’s loop warning for 0–1 slides.

- **Dependencies**
  - Dockerfile.rca: bump `jq` to `1.6-2.1+deb12u2` to match bookworm-security and fix apt build failures.

<sup>Written for commit 118103e7cbcca58fc2a2d58f5dce49e9f02ff215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

