### PR TITLE
docs(#102): reconcile agents.md/README make-target docs with the Makefile

### DIFF
--- a/Dockerfile.rca
+++ b/Dockerfile.rca
@@ -14,7 +14,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
       ca-certificates=20230311+deb12u1 \
       curl=7.88.1-10+deb12u14 \
-      jq=1.6-2.1+deb12u1 \
+      jq=1.6-2.1+deb12u2 \
       make=4.3-4.1 \
       tar=1.34+dfsg-1.2+deb12u1; \
     rm -rf /var/lib/apt/lists/*; \

--- a/README.md
+++ b/README.md
@@ -19,22 +19,24 @@ Install dependencies:
 bun install
 ```
 
-Run the common workflows through `make`:
+`make help` prints the authoritative, self-documenting list of every target — run it first:
 
 ```bash
-make build
-make lint
-make lint-next
-make lint-tsc
-make storybook-start
-make storybook-build
-make test-unit
-make test-e2e
-make test-visual
-make lighthouse-desktop
-make lighthouse-mobile
-make lint-metrics
+make help
 ```
+
+Every pull request must pass the gating targets below; run the ones your change touches
+locally before pushing. See [agents.md](agents.md) for which test layer a given change needs.
+
+| Target                  | What it gates                                                |
+| ----------------------- | ------------------------------------------------------------ |
+| `make lint`             | ESLint, TypeScript, markdownlint, Prettier, dependency gates |
+| `make test-unit`        | Jest unit suite (components, hooks, pure logic) in jsdom     |
+| `make test-integration` | Jest composition suite: composed components, real children   |
+| `make test-e2e`         | Playwright behavior against a Storybook build                |
+| `make test-visual`      | Playwright visual-regression snapshots                       |
+| `make test-mutation`    | Stryker mutation-strength gate                               |
+| `make test-bats`        | Bats coverage of Makefile shell flows and their contracts    |
 
 The `lint-metrics` target runs a `rust-code-analysis` complexity gate over `src/`. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the policy details and remediation guidance.
@@ -84,6 +86,8 @@ in `CONTRIBUTING.md` for what it enforces, how it complements ESLint, and how to
 
 - This repository is a React UI library, not a Next.js app.
 - Source code lives under `src`; there is no `pages` app surface.
+- `make lint-next` runs ESLint. The name predates the library split — it is not
+  Next.js-specific — and is kept only to avoid renaming churn across CI and tooling.
 
 ## Security
 

--- a/agents.md
+++ b/agents.md
@@ -29,21 +29,26 @@ ONLY with a recorded, concrete justification (see Step 3) — never by silent om
 Choose the layer(s) that actually exercise the change; a single component change often needs
 more than one. Match the change to the suite and run its verification command.
 
-| Test layer        | Use it for                                      | Command            |
-| ----------------- | ----------------------------------------------- | ------------------ |
-| Unit              | Components, hooks, theme, and pure client logic | `make test-unit`   |
-| End-to-end (e2e)  | Storybook-driven component behavior end to end  | `make test-e2e`    |
-| Visual regression | Any change to rendered UI, layout, or styling   | `make test-visual` |
+| Test layer        | Use it for                                      | Command                 |
+| ----------------- | ----------------------------------------------- | ----------------------- |
+| Unit              | Components, hooks, theme, and pure client logic | `make test-unit`        |
+| Integration       | Composed components rendered with real children | `make test-integration` |
+| End-to-end (e2e)  | Storybook-driven component behavior end to end  | `make test-e2e`         |
+| Visual regression | Any change to rendered UI, layout, or styling   | `make test-visual`      |
 
 Unit tests run on Jest with React Testing Library in a jsdom env; specs are centralized in
-`tests/unit/**/*.test.tsx` (and `*.test.ts` for non-render logic). E2e and visual specs are
-Playwright run against a Storybook build (`tests/e2e/**`, `tests/visual/**`); visual snapshots
-sit in adjacent `*-snapshots/` folders. There is no separate `make test-integration` target:
-integration-level coverage (component composition and interaction) lives in the Jest unit
-suite via React Testing Library — exercise composed behavior there, not just isolated units.
-Every test file lives under the root `tests/` tree, and `make lint-test-structure` (run on
-every pull request) fails on any `*.test.*` or `*.spec.*` file placed outside it — see
-CONTRIBUTING.md for the canonical layout.
+`tests/unit/**/*.test.tsx` (and `*.test.ts` for non-render logic). Integration specs live in
+`tests/integration/**/*.integration.test.tsx` and run via `make test-integration` (Jest with
+`jest.integration.config.ts`): they render composed components with their real children — no
+child mocks — to verify cross-component behavior, and enforce a 100% coverage gate scoped to
+the composition/orchestration components (AuthSkeleton, Layout, UiForm, UiTextFieldForm, and
+the UiFooter / UiCardList subtrees). Reach for the integration layer when a change wires
+components together or changes how a container drives its children; a change contained to a
+single leaf component needs only the unit layer. E2e and visual specs are Playwright run
+against a Storybook build (`tests/e2e/**`, `tests/visual/**`); visual snapshots sit in
+adjacent `*-snapshots/` folders. Every test file lives under the root `tests/` tree, and
+`make lint-test-structure` (run on every pull request) fails on any `*.test.*` or `*.spec.*`
+file placed outside it — see CONTRIBUTING.md for the canonical layout.
 
 Storybook is a first-class coverage layer here, not just documentation. Every new or enhanced
 component MUST ship stories that render its full state matrix (see Step 2); e2e and visual
@@ -114,6 +119,7 @@ pass. Run the layer commands you touched, then the project lint gate.
 ```bash
 bun x prettier . --write   # Auto-format (lint runs format-check, so format first)
 make test-unit             # Jest unit suite (jsdom)
+make test-integration      # Jest composition suite (for cross-component changes)
 make test-e2e              # Storybook-driven behavior (for behavior changes)
 make test-visual           # Visual regression (for UI or styling changes)
 make lint                  # Full gate: ESLint, TypeScript, markdownlint, and format-check

--- a/tests/bats/doc_make_target_coverage.bats
+++ b/tests/bats/doc_make_target_coverage.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+# Guards against command-documentation drift (issue #102). The human/agent
+# operating docs (README.md, agents.md) must stay honest about the Makefile:
+#
+#   1. Every `make <target>` they reference must actually exist in the Makefile,
+#      so a doc can never deny or misname a target the machine defines/runs.
+#   2. Every core pull-request gate surfaced in the README gating table must be
+#      documented, so a newcomer or agent can reproduce the CI gate from the docs.
+#
+# This is the docs-equivalent of tests/bats/make-target-coverage.tsv, which keeps
+# the Bats coverage manifest honest against the same Makefile.
+
+load './test_helper.bash'
+
+# The core pull-request gates surfaced in the README gating table — the set a
+# contributor is expected to run locally. This is a curated subset (heavy suites
+# such as memory-leak and lighthouse are documented in agents.md but not listed
+# here); keep it in sync with the README table. Adding a target here means it
+# must be documented in README.md or agents.md.
+GATING_TARGETS=(lint test-unit test-integration test-e2e test-visual test-mutation test-bats)
+
+# Print, one per line, every `make <target>` invocation that appears in a CODE
+# context (a fenced code block or an inline `code` span) of the given Markdown
+# file. Two things are deliberately excluded so the guard never fails a valid doc:
+#   - prose such as "does NOT make the work done" (not in code formatting), and
+#   - the English verb in a comment such as "# make sure the container is up"
+#     (`make` there is not at a shell command position).
+# To achieve the latter, every code line is prefixed with a synthetic "; "
+# separator, then only a `make` sitting at a command position — line start or
+# right after a `;`, `&`, `|`, or `(` — is treated as an invocation.
+extract_documented_targets() {
+  local file="$1"
+  {
+    # Bodies of ``` fenced code blocks (fences sit at column 0 in these docs).
+    awk '/^```/ { f = 1 - f; next } f { print }' "$file"
+    # Contents of inline `code` spans, one per line.
+    grep -oE '`[^`]+`' "$file" | tr -d '`'
+  } \
+    | sed 's/^/; /' \
+    | grep -oE '[;&|(] *make [a-z][a-z0-9-]+' \
+    | sed 's/.*make //' \
+    | sort -u
+}
+
+# Print, one per line, every real target defined in the Makefile, excluding the
+# dot-directives (.PHONY, .DEFAULT_GOAL, ...). Mirrors the parsing used by
+# target_coverage_contract.bats so both contracts see the same target set.
+makefile_targets() {
+  awk -F: '/^[A-Za-z0-9_.-]+:/ { if ($1 !~ /^\./) print $1 }' \
+    "$PROJECT_ROOT/Makefile" | sort -u
+}
+
+assert_documented_targets_exist() {
+  local doc="$1"
+  local known missing=""
+  known="$(makefile_targets)"
+
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+    if ! printf '%s\n' "$known" | grep -qxF "$target"; then
+      missing="$missing $target"
+    fi
+  done < <(extract_documented_targets "$PROJECT_ROOT/$doc")
+
+  if [ -n "$missing" ]; then
+    echo "$doc references make target(s) the Makefile does not define:$missing" >&2
+    return 1
+  fi
+}
+
+@test "every make target documented in README.md exists in the Makefile" {
+  assert_documented_targets_exist README.md
+}
+
+@test "every make target documented in agents.md exists in the Makefile" {
+  assert_documented_targets_exist agents.md
+}
+
+@test "every core pull-request gate in the README table is documented in the docs" {
+  local documented undocumented=""
+  documented="$(
+    {
+      extract_documented_targets "$PROJECT_ROOT/README.md"
+      extract_documented_targets "$PROJECT_ROOT/agents.md"
+    } | sort -u
+  )"
+
+  local gate
+  for gate in "${GATING_TARGETS[@]}"; do
+    if ! printf '%s\n' "$documented" | grep -qxF "$gate"; then
+      undocumented="$undocumented $gate"
+    fi
+  done
+
+  if [ -n "$undocumented" ]; then
+    echo "Core gating target(s) not documented in README.md or agents.md:$undocumented" >&2
+    return 1
+  fi
+}
+
+@test "agents.md documents the make test-integration target instead of denying it" {
+  # The retired sentence "There is no separate \`make test-integration\` target".
+  run grep -Ei 'no separate.*test-integration' "$PROJECT_ROOT/agents.md"
+  [ "$status" -ne 0 ]
+
+  run grep -F 'make test-integration' "$PROJECT_ROOT/agents.md"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What & why

The three documents describing how to operate this repo contradicted each other,
and one of them (`agents.md`) is the mandatory AI-agent contract:

- `agents.md` asserted **"There is no separate `make test-integration` target"** —
  false: `Makefile` defines `test-integration` (Jest + `jest.integration.config.ts`)
  and `.github/workflows/integration-testing.yml` runs it on every PR. An agent
  obeying its contract would never run the integration suite locally and would put
  composition tests in the wrong layer.
- `README.md` documented a hand-maintained subset of make targets that omitted
  several required PR gates, so a newcomer couldn't reproduce the CI gate locally.
- There was no drift guard, even though the repo otherwise engineers against this
  class of drift (`tests/bats/make-target-coverage.tsv`).

## Changes

- **`agents.md`** — replaced the false claim with an accurate description of the
  integration layer (composed components rendered with their real children, a 100%
  coverage gate scoped to the composition/orchestration components, specs under
  `tests/integration/`), plus when to reach for it vs. unit-only. Added
  `make test-integration` to the **Step 1 layer table** and the **Step 5
  verification block**.
- **`README.md`** — replaced the hand-maintained command list with a pointer to
  `make help` (authoritative) plus a table of the seven core PR-gating targets.
  Documented the historical `lint-next` name (kept — it runs ESLint and is not
  Next.js-specific; renaming would churn CI/tooling for no functional gain).
- **`tests/bats/doc_make_target_coverage.bats`** (new) — drift guard that fails if
  README/agents.md reference a `make <target>` the Makefile doesn't define, or if a
  core PR gate goes undocumented. It extracts `make` invocations only from **code
  context at a shell command position**, so prose like "make the work done" and
  comment verbs like "# make sure …" never trip it. Auto-discovered by
  `make test-bats -r tests/bats`.

## Acceptance criteria

- [x] `agents.md` no longer contains "There is no separate `make test-integration`
      target" and lists it in both the layer table and Step 5.
- [x] Every `make <target>` in README.md and agents.md exists in the Makefile
      (enforced by the new Bats test).
- [x] The new Bats test fails if a documented target is removed from the Makefile
      or a core gate is undocumented (verified with negative-control experiments).
- [x] README delegates to `make help` **and** lists all core PR-gating targets.
- [x] `make lint-md` and `make test-bats` pass.
- [x] `lint-next` naming decided and documented (kept + rationale).

## Verification

- `make test-bats` (in the Alpine/busybox container): **269/269 pass**, including
  the 4 new drift-guard tests.
- `prettier --check` and `markdownlint` clean on both docs (MD013 ≤ 100; longest
  changed lines 97/98).
- Negative controls confirm the guard bites on phantom targets, Makefile removals,
  and undocumented gates, and ignores prose/comment false positives.
- Reviewed by a 4-lens adversarial pass (AC-faithfulness, guard-robustness,
  doc-accuracy, regressions); the two robustness findings it raised are folded in.

Closes #102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `agents.md` and `README.md` with the `Makefile`, adds a drift guard for documented `make` targets, and fixes the rca image build by updating the `jq` pin. Closes #102.

- **Bug Fixes**
  - `agents.md`: Remove the false “no `make test-integration`” claim; document the integration layer (composed components with real children, 100% coverage scope, `tests/integration/**`, Jest + `jest.integration.config.ts`). Add `make test-integration` to the layer table and Step 5.
  - `README.md`: Delegate the full command list to `make help` and add a table of core PR-gating targets (`lint`, `test-unit`, `test-integration`, `test-e2e`, `test-visual`, `test-mutation`, `test-bats`). Note the historical `lint-next` name.
  - `Dockerfile.rca`: Bump `jq` to `1.6-2.1+deb12u2` to fix rca image builds after the `libjq1` security update.

- **New Features**
  - Add `tests/bats/doc_make_target_coverage.bats` to fail when docs reference missing `make` targets or omit a core gate. Extracts only code-formatted `make` invocations to avoid prose false positives. Auto-discovered by `make test-bats`.

<sup>Written for commit 3bb9085089bd6fe05986542a2665cf7ff5b232e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

