### PR TITLE
build(#110): bundled type declarations in build + publish public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out/
 # production
 build/
 
+# type-declaration rollup scratch dir (tsc -> API Extractor)
+temp/
+
 # misc
 .DS_Store
 *.pem

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "projectFolder": ".",
+  "mainEntryPointFilePath": "<projectFolder>/temp/dts/components/index.d.ts",
+  "bundledPackages": [],
+  "compiler": {
+    "tsconfigFilePath": "<projectFolder>/tsconfig.api-extractor.json"
+  },
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "<projectFolder>/build/index.d.ts"
+  },
+  "apiReport": { "enabled": false },
+  "docModel": { "enabled": false },
+  "tsdocMetadata": { "enabled": false },
+  "messages": {
+    "compilerMessageReporting": {
+      "default": { "logLevel": "warning" }
+    },
+    "extractorMessageReporting": {
+      "default": { "logLevel": "warning" },
+      "ae-missing-release-tag": { "logLevel": "none" },
+      "ae-unresolved-link": { "logLevel": "none" }
+    },
+    "tsdocMessageReporting": {
+      "default": { "logLevel": "none" }
+    }
+  }
+}

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { createRequire } from 'module';
@@ -58,6 +58,16 @@ async function generateTypeDeclarations() {
   if (!result.succeeded) {
     throw new Error(
       `API Extractor failed with ${result.errorCount} error(s) and ${result.warningCount} warning(s).`
+    );
+  }
+
+  // Invariant: the rollup must be self-contained. Fail the build if any internal
+  // `@/*` path-alias import leaked through instead of being inlined — such a file
+  // would not resolve for consumers of the published package.
+  const rollupPath = path.resolve(currentDir, 'build', 'index.d.ts');
+  if (/\bfrom\s+['"]@\//.test(readFileSync(rollupPath, 'utf8'))) {
+    throw new Error(
+      'build/index.d.ts contains unresolved "@/..." path-alias imports; the API Extractor rollup did not inline them.'
     );
   }
 }

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { createRequire } from 'module';
@@ -41,6 +41,13 @@ async function generateTypeDeclarations() {
   // is produced in two steps: tsc emits per-file declarations (keeping the `@/*`
   // path aliases) under temp/dts, then API Extractor rolls them into a single
   // self-contained build/index.d.ts (resolving the aliases and inlining internals).
+  //
+  // tsc does not prune stale declarations for deleted/renamed sources, so a reused
+  // temp/dts could feed API Extractor leftover files and make the rollup depend on
+  // build history. Start from a clean intermediate directory for a deterministic result.
+  const dtsOutDir = path.resolve(currentDir, 'temp', 'dts');
+  rmSync(dtsOutDir, { recursive: true, force: true });
+
   const tscBin = require.resolve('typescript/bin/tsc');
   execFileSync(process.execPath, [tscBin, '-p', path.resolve(currentDir, 'tsconfig.dts.json')], {
     stdio: 'inherit',
@@ -62,10 +69,12 @@ async function generateTypeDeclarations() {
   }
 
   // Invariant: the rollup must be self-contained. Fail the build if any internal
-  // `@/*` path-alias import leaked through instead of being inlined — such a file
-  // would not resolve for consumers of the published package.
+  // `@/*` path-alias reference leaked through instead of being inlined — such a file
+  // would not resolve for consumers of the published package. Covers every alias form
+  // emitted into a `.d.ts`: `from "@/…"`, side-effect `import "@/…"`, and inline
+  // dynamic-import types `import("@/…").Type`.
   const rollupPath = path.resolve(currentDir, 'build', 'index.d.ts');
-  if (/\bfrom\s+['"]@\//.test(readFileSync(rollupPath, 'utf8'))) {
+  if (/(?:\bfrom\s+|\bimport\s*\(?\s*)['"]@\//.test(readFileSync(rollupPath, 'utf8'))) {
     throw new Error(
       'build/index.d.ts contains unresolved "@/..." path-alias imports; the API Extractor rollup did not inline them.'
     );

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import { createRequire } from 'module';
+import { execFileSync } from 'child_process';
 
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
@@ -33,6 +34,32 @@ if (!existsSync(entryPoint)) {
     'Skipping build because this bootstrap PR does not include src/components/index.ts yet.\n'
   );
   process.exit(0);
+}
+
+async function generateTypeDeclarations() {
+  // esbuild does not emit type declarations, so the library's published `.d.ts`
+  // is produced in two steps: tsc emits per-file declarations (keeping the `@/*`
+  // path aliases) under temp/dts, then API Extractor rolls them into a single
+  // self-contained build/index.d.ts (resolving the aliases and inlining internals).
+  const tscBin = require.resolve('typescript/bin/tsc');
+  execFileSync(process.execPath, [tscBin, '-p', path.resolve(currentDir, 'tsconfig.dts.json')], {
+    stdio: 'inherit',
+    cwd: currentDir,
+  });
+
+  const { Extractor, ExtractorConfig } = await import('@microsoft/api-extractor');
+  const extractorConfig = ExtractorConfig.loadFileAndPrepare(
+    path.resolve(currentDir, 'api-extractor.json')
+  );
+  const result = Extractor.invoke(extractorConfig, {
+    localBuild: true,
+    showVerboseMessages: false,
+  });
+  if (!result.succeeded) {
+    throw new Error(
+      `API Extractor failed with ${result.errorCount} error(s) and ${result.warningCount} warning(s).`
+    );
+  }
 }
 
 esbuild
@@ -74,7 +101,8 @@ esbuild
       'process.env.NODE_ENV': '"production"',
     },
   })
+  .then(generateTypeDeclarations)
   .catch(error => {
-    process.stderr.write(`esbuild failed: ${error.message ?? error}\n`);
+    process.stderr.write(`Build failed: ${error.message ?? error}\n`);
     process.exit(1);
   });

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "**/*.css"
   ],
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",

--- a/tsconfig.api-extractor.json
+++ b/tsconfig.api-extractor.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["temp/dts/*"]
+    },
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node", "react", "react-dom"],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx"
+  },
+  "include": ["temp/dts/**/*.d.ts"]
+}

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "outDir": "temp/dts",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "incremental": false,
+    "types": ["node", "react", "react-dom"]
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "src/**/*.stories.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}


### PR DESCRIPTION
## What & why

Makes the package **reproducibly releasable to npm**. Two gaps blocked a clean release:

1. **Types were never generated.** `package.json` advertises `"types": "./build/index.d.ts"`, but the build only ran esbuild — which does **not** emit `.d.ts`. So the published package pointed at a file that never existed, and TypeScript consumers would fall back to untyped/`any`. (`@microsoft/api-extractor` was already a devDependency and a `generate-ts-doc` target existed, but no `api-extractor.json` was ever added — the pipeline was half-wired.)
2. **`publishConfig.access` was `restricted`** — the package is meant to publish **public**.

Closes #110.

## Changes

- **`build.config.mjs`** — after esbuild, generate bundled declarations in two steps, so a single `make build` (`node ./build.config.mjs`) now emits runtime **and** types:
  - `tsc -p tsconfig.dts.json` → per-file `.d.ts` under `temp/dts/` (keeps the `@/*` path aliases),
  - **API Extractor** → rolls them into a single self-contained `build/index.d.ts` (resolves `@/*` → `temp/dts/*`, inlines internal types).
- **`tsconfig.dts.json`**, **`tsconfig.api-extractor.json`**, **`api-extractor.json`** — the declaration-emit + rollup config.
- **`package.json`** — `publishConfig.access`: `restricted` → `public`.
- **`.gitignore`** — ignore the `temp/` scratch dir.

No Makefile target was added or renamed (folded into the existing `build` recipe), so the make-target-coverage contract is untouched.

## Verification (local)

- `node ./build.config.mjs` → `build/index.mjs` + `build/index.css` + **`build/index.d.ts`** ✅
- `build/index.d.ts` is self-contained (no `@/*` imports — only peer-dep imports like `@mui/material`, `react`, `react-hook-form`) and type-checks with `tsc --noEmit` (exit 0) ✅
- `npm publish --dry-run` → tarball includes `build/index.d.ts` (17 files) and publishes with **public access** ✅
- `prettier --check`, `tsc` (project), `depcruise` — all green; `Makefile` unchanged ✅

## Follow-up

Once merged, publishing `@vilnacrm/ui-toolkit@0.1.0` from `main` will ship complete, correctly-typed artifacts. (Ownership/`npm owner add` handled separately.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundle and publish TypeScript declarations as a single `build/index.d.ts`, and set npm publish access to public. Resolves #110.

- **Refactors**
  - Type pipeline: `tsc` emits to a cleaned `temp/dts`, then `@microsoft/api-extractor` rolls up to `build/index.d.ts`; build fails if any `@/*` alias remains (covers `from`, side-effect `import`, and dynamic `import()` types).
  - Added configs (`tsconfig.dts.json`, `tsconfig.api-extractor.json`, `api-extractor.json`); `build.config.mjs` runs this after `esbuild`; `temp/` is git-ignored.
  - `package.json`: `publishConfig.access` set to `public`.

<sup>Written for commit 96ed2116174149545b04f27ebb61199b4b1006f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

