### PR TITLE
feat(release): attach the packed npm tarball to every GitHub release

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -130,12 +130,15 @@ module.exports = {
         '(e.g. jest, storybook, webpack, eslint). Runtime libraries this ' +
         'library mirrors into both devDependencies and peerDependencies are ' +
         'spared via dependencyTypesNot: [npm-peer] (combinedDependencies tags ' +
-        'them as both npm-dev and npm-peer), so only true dev-only modules fail.',
+        'them as both npm-dev and npm-peer), so only true dev-only modules ' +
+        'fail. swiper is spared via pathNot: build.config.mjs deliberately ' +
+        'bundles it (and its carousel CSS) into the published artifact, so it ' +
+        'sits in devDependencies without being a dev tool.',
       from: { path: '^src', pathNot: '[.](?:spec|test|stories)[.](?:tsx?|jsx?)$' },
       to: {
         dependencyTypes: ['npm-dev'],
         dependencyTypesNot: ['npm-peer', 'type-only'],
-        pathNot: ['node_modules/@types/'],
+        pathNot: ['node_modules/@types/', 'node_modules/swiper/'],
       },
     },
     // ---- Components-centric boundaries (replace CRM bulletproof-react layering) ----

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -47,6 +47,16 @@ jobs:
           output-file: 'CHANGELOG.md'
           version-file: 'package.json'
 
+      # The changelog step bumps package.json in the working tree before the image
+      # is built, so the packed tarball carries the version that is being released.
+      - name: Start docker build environment
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: make start-bun
+
+      - name: Pack the publishable tarball
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: make package
+
       - name: Create Release
         uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
@@ -56,3 +66,8 @@ jobs:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
+          files: dist/*.tgz
+
+      - name: Stop docker build environment
+        if: ${{ always() && steps.changelog.outputs.skipped == 'false' }}
+        run: make down

--- a/.github/workflows/release-asset-check.yml
+++ b/.github/workflows/release-asset-check.yml
@@ -1,0 +1,94 @@
+name: release asset check
+
+on:
+  # Daily, so a stalled release pipeline is discovered within a day rather than
+  # after months of silent failures on main.
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-asset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+
+    # No checkout step: every assertion is answered by the GitHub API through the
+    # preinstalled gh CLI, so this job needs no working tree.
+    steps:
+      - name: Assert the newest release tag ships a tarball
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: .github/workflows/autorelease.yml
+        run: |
+          set -euo pipefail
+
+          # The tags API orders by commit date, not by version, hence sort -V.
+          # Only stable vX.Y.Z tags count; autorelease.yml never tags prereleases.
+          gh api --paginate "repos/$REPO/tags" --jq '.[].name' > tags.txt
+          tag="$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' tags.txt | sort -V | tail -n 1 || true)"
+
+          if [[ -z "$tag" ]]; then
+            echo "::notice::No v-prefixed release tag exists yet, so there is nothing" \
+              "to verify. This is the expected pre-first-release state."
+            exit 0
+          fi
+
+          if ! gh api "repos/$REPO/releases/tags/$tag" > release.json; then
+            echo "::error::Tag $tag has no GitHub release. The release pipeline is" \
+              "broken: the Create Release step in $WORKFLOW never ran for this tag." \
+              "Check the newest run of that workflow on main."
+            exit 1
+          fi
+
+          assets="$(jq '[.assets[].name | select(endswith(".tgz"))] | length' release.json)"
+          if [[ "$assets" -eq 0 ]]; then
+            echo "::error::Release $tag carries no .tgz asset, so consumers cannot" \
+              "install it. The packaging steps in $WORKFLOW (make package, then the" \
+              "files: dist/*.tgz upload) did not produce or attach a tarball."
+            exit 1
+          fi
+
+          echo "Release $tag ships $assets .tgz asset(s)."
+
+      - name: Assert the release workflow is not failing on main
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: .github/workflows/autorelease.yml
+        run: |
+          set -euo pipefail
+
+          runs="repos/$REPO/actions/workflows/autorelease.yml/runs"
+          if ! gh api "$runs?branch=main&status=completed&per_page=1" > runs.json; then
+            echo "::notice::Could not read runs for $WORKFLOW, so its health was not" \
+              "checked. The workflow may never have been registered on main."
+            exit 0
+          fi
+
+          conclusion="$(jq -r '.workflow_runs[0].conclusion // "none"' runs.json)"
+          url="$(jq -r '.workflow_runs[0].html_url // ""' runs.json)"
+
+          if [[ "$conclusion" == "none" ]]; then
+            echo "::notice::$WORKFLOW has no completed run on main yet."
+            exit 0
+          fi
+
+          if [[ "$conclusion" == "failure" ]]; then
+            echo "::error::The newest completed run of $WORKFLOW on main failed, so no" \
+              "release can be cut and no tarball can be published. Open $url for the" \
+              "failing step, then fix $WORKFLOW."
+            exit 1
+          fi
+
+          echo "Newest completed $WORKFLOW run on main concluded '$conclusion'."

--- a/.github/workflows/release-asset-check.yml
+++ b/.github/workflows/release-asset-check.yml
@@ -43,22 +43,34 @@ jobs:
             exit 0
           fi
 
-          if ! gh api "repos/$REPO/releases/tags/$tag" > release.json; then
-            echo "::error::Tag $tag has no GitHub release. The release pipeline is" \
-              "broken: the Create Release step in $WORKFLOW never ran for this tag." \
-              "Check the newest run of that workflow on main."
+          status=0
+          gh api "repos/$REPO/releases/tags/$tag" > release.json 2> api-error.txt \
+            || status=$?
+          if [[ "$status" -ne 0 ]]; then
+            if grep -q 'HTTP 404' api-error.txt; then
+              echo "::error::Tag $tag has no GitHub release. The release pipeline is" \
+                "broken: the Create Release step in $WORKFLOW never ran for this tag." \
+                "Check the newest run of that workflow on main."
+            else
+              cat api-error.txt
+              echo "::error::Could not read the release for tag $tag, so release" \
+                "health is unverified. Re-run this workflow once the API call works."
+            fi
             exit 1
           fi
 
-          assets="$(jq '[.assets[].name | select(endswith(".tgz"))] | length' release.json)"
-          if [[ "$assets" -eq 0 ]]; then
-            echo "::error::Release $tag carries no .tgz asset, so consumers cannot" \
-              "install it. The packaging steps in $WORKFLOW (make package, then the" \
-              "files: dist/*.tgz upload) did not produce or attach a tarball."
+          # Consumers install the one documented asset name, so any other .tgz
+          # (stale, misnamed, or manually attached) must not satisfy this check.
+          expected="vilnacrm-ui-toolkit-${tag#v}.tgz"
+          if ! jq -e --arg name "$expected" \
+            '.assets[] | select(.name == $name)' release.json > /dev/null; then
+            echo "::error::Release $tag does not carry $expected, so consumers" \
+              "cannot install it. The packaging steps in $WORKFLOW (make package," \
+              "then the files: dist/*.tgz upload) did not attach that tarball."
             exit 1
           fi
 
-          echo "Release $tag ships $assets .tgz asset(s)."
+          echo "Release $tag ships $expected."
 
       - name: Assert the release workflow is not failing on main
         if: always()
@@ -70,10 +82,21 @@ jobs:
           set -euo pipefail
 
           runs="repos/$REPO/actions/workflows/autorelease.yml/runs"
-          if ! gh api "$runs?branch=main&status=completed&per_page=1" > runs.json; then
-            echo "::notice::Could not read runs for $WORKFLOW, so its health was not" \
-              "checked. The workflow may never have been registered on main."
-            exit 0
+          status=0
+          gh api "$runs?branch=main&status=completed&per_page=1" > runs.json \
+            2> api-error.txt || status=$?
+          if [[ "$status" -ne 0 ]]; then
+            # Only the expected pre-registration state may pass silently; any
+            # other API failure would otherwise mask a broken release pipeline.
+            if grep -q 'HTTP 404' api-error.txt; then
+              echo "::notice::$WORKFLOW is not registered on main yet, so its" \
+                "health was not checked. This is the expected bootstrap state."
+              exit 0
+            fi
+            cat api-error.txt
+            echo "::error::Could not read runs for $WORKFLOW, so release-pipeline" \
+              "health is unverified. Re-run this workflow once the API call works."
+            exit 1
           fi
 
           conclusion="$(jq -r '.workflow_runs[0].conclusion // "none"' runs.json)"
@@ -84,11 +107,13 @@ jobs:
             exit 0
           fi
 
-          if [[ "$conclusion" == "failure" ]]; then
-            echo "::error::The newest completed run of $WORKFLOW on main failed, so no" \
-              "release can be cut and no tarball can be published. Open $url for the" \
-              "failing step, then fix $WORKFLOW."
+          # Cancelled, timed-out, and action-required runs leave the release
+          # unpublished just as surely as a failure, so only success is healthy.
+          if [[ "$conclusion" != "success" ]]; then
+            echo "::error::The newest completed run of $WORKFLOW on main concluded" \
+              "'$conclusion' rather than 'success', so the newest release may never" \
+              "have been cut. Open $url for the failing step, then fix $WORKFLOW."
             exit 1
           fi
 
-          echo "Newest completed $WORKFLOW run on main concluded '$conclusion'."
+          echo "Newest completed $WORKFLOW run on main concluded 'success'."

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out/
 # production
 build/
 
+# packed release tarball (make package)
+dist/
+
 # type-declaration rollup scratch dir (tsc -> API Extractor)
 temp/
 

--- a/CONSUMING.md
+++ b/CONSUMING.md
@@ -1,0 +1,103 @@
+# Agent brief: consume the ui-toolkit release tarball
+
+Instructions for an agent wiring `@vilnacrm/ui-toolkit` into the `crm` or `website` repository.
+Work in the consumer repository, not in `ui-toolkit`.
+
+## What is published
+
+`@vilnacrm/ui-toolkit` is not on the public npm registry. Every push to `main` runs
+`.github/workflows/autorelease.yml`, which derives the next version from the conventional-commit
+history, tags it, packs the library with `npm pack`, and attaches
+`vilnacrm-ui-toolkit-<version>.tgz` to the GitHub release. That tarball is byte-for-byte what
+`npm publish` would have uploaded — same entry points, same `exports` map, same peer ranges.
+
+`VilnaCRM-Org/ui-toolkit` is public, so the asset downloads without a token, an `.npmrc` entry, or
+a CI secret.
+
+The package is ESM-only and exposes two entry points:
+
+- `@vilnacrm/ui-toolkit` — the components, themes, and tokens, with bundled type declarations.
+- `@vilnacrm/ui-toolkit/styles.css` — the stylesheet, carrying the Swiper carousel CSS and the
+  Inter and Golos Text font faces.
+
+## Peer dependencies the consumer must already provide
+
+| Peer                                | Range     |
+| ----------------------------------- | --------- |
+| `react`, `react-dom`                | `^19.0.0` |
+| `@mui/material`, `@mui/system`      | `^9.0.0`  |
+| `@emotion/react`, `@emotion/styled` | `^11.0.0` |
+| `react-hook-form`                   | `^7.0.0`  |
+| `i18next`                           | `^23.0.0` |
+| `react-i18next`                     | `^14.0.0` |
+
+`website` already satisfies all of these. `crm` is on React 18.3 and MUI 7, so its install will
+report peer mismatches until its React 19 / MUI 9 upgrade lands. If you are working in `crm` and
+that upgrade has not happened, stop and report the mismatch instead of forcing the install — the
+components use MUI 9 APIs and will fail at runtime under MUI 7.
+
+## Wiring the dependency
+
+Resolve the tarball URL of the newest release:
+
+```bash
+gh release view --repo VilnaCRM-Org/ui-toolkit \
+  --json tagName,assets --jq '.assets[] | select(.name | endswith(".tgz")) | .url'
+```
+
+Add it in the consumer repository:
+
+```bash
+VERSION=0.1.0
+BASE=https://github.com/VilnaCRM-Org/ui-toolkit/releases/download
+bun add "$BASE/v$VERSION/vilnacrm-ui-toolkit-$VERSION.tgz"
+```
+
+That writes the full URL into `dependencies` and records the tarball's `sha512` integrity hash in
+`bun.lock`. Commit both files together — the hash is what makes the pin tamper-evident.
+
+Import the stylesheet exactly once, in the application's root entry, before any toolkit component
+renders:
+
+```ts
+import '@vilnacrm/ui-toolkit/styles.css';
+```
+
+Then import components by name:
+
+```tsx
+import { UiButton, UiSearchInput } from '@vilnacrm/ui-toolkit';
+```
+
+## Checking the wiring holds
+
+Run, in the consumer repository:
+
+```bash
+bun install --frozen-lockfile
+make lint-tsc
+make test-unit
+```
+
+A clean `--frozen-lockfile` install proves the committed hash matches the published asset. The
+type-check proves the bundled declarations resolve. If the repository names these targets
+differently, use its own type-check and unit-test targets.
+
+## Moving to a later release
+
+Re-run the two commands under [Wiring the dependency](#wiring-the-dependency) with the new
+version; `bun add` rewrites both `package.json` and `bun.lock`. Because the URL pins an immutable
+release asset there are no semver ranges: every upgrade is an explicit, reviewable diff, and
+nothing moves under the consumer without a commit.
+
+## Failure modes worth knowing
+
+- Do not install the git tag (`bun add github:VilnaCRM-Org/ui-toolkit#v0.1.0`). The tag carries
+  source only — `build/` is gitignored and there is no `prepare` script — so the install yields a
+  package whose every entry point resolves to a missing file.
+- Container and CI installs need network access to `objects.githubusercontent.com`, which is where
+  release-asset downloads redirect. An allowlisted egress proxy has to permit it.
+- Never re-cut a release with an existing version number. The old `sha512` is pinned in every
+  consumer's `bun.lock`, so a replaced asset turns into a hard install failure across both repos.
+  Publish a new version instead.
+- The package is ESM-only. `require('@vilnacrm/ui-toolkit')` will not work; use `import`.

--- a/CONSUMING.md
+++ b/CONSUMING.md
@@ -20,16 +20,19 @@ The package is ESM-only and exposes two entry points:
 - `@vilnacrm/ui-toolkit/styles.css` — the stylesheet, carrying the Swiper carousel CSS and the
   Inter and Golos Text font faces.
 
+Swiper is bundled into both entry points rather than declared as a peer, so the consumer does not
+install it for the toolkit's sake.
+
 ## Peer dependencies the consumer must already provide
 
-| Peer                                | Range     |
-| ----------------------------------- | --------- |
-| `react`, `react-dom`                | `^19.0.0` |
-| `@mui/material`, `@mui/system`      | `^9.0.0`  |
-| `@emotion/react`, `@emotion/styled` | `^11.0.0` |
-| `react-hook-form`                   | `^7.0.0`  |
-| `i18next`                           | `^23.0.0` |
-| `react-i18next`                     | `^14.0.0` |
+| Peer                                | Range              |
+| ----------------------------------- | ------------------ |
+| `react`, `react-dom`                | `^19.0.0`          |
+| `@mui/material`, `@mui/system`      | `^9.0.0`           |
+| `@emotion/react`, `@emotion/styled` | `^11.0.0`          |
+| `react-hook-form`                   | `^7.0.0`           |
+| `i18next`                           | `>=23.0.0 <27.0.0` |
+| `react-i18next`                     | `>=14.0.0 <18.0.0` |
 
 `website` already satisfies all of these. `crm` is on React 18.3 and MUI 7, so its install will
 report peer mismatches until its React 19 / MUI 9 upgrade lands. If you are working in `crm` and
@@ -45,13 +48,16 @@ gh release view --repo VilnaCRM-Org/ui-toolkit \
   --json tagName,assets --jq '.assets[] | select(.name | endswith(".tgz")) | .url'
 ```
 
-Add it in the consumer repository:
+Add it in the consumer repository, taking the version from that same release:
 
 ```bash
-VERSION=0.1.0
+VERSION=$(gh release view --repo VilnaCRM-Org/ui-toolkit \
+  --json tagName --jq '.tagName | ltrimstr("v")')
 BASE=https://github.com/VilnaCRM-Org/ui-toolkit/releases/download
 bun add "$BASE/v$VERSION/vilnacrm-ui-toolkit-$VERSION.tgz"
 ```
+
+Set `VERSION` by hand instead to pin an older release.
 
 That writes the full URL into `dependencies` and records the tarball's `sha512` integrity hash in
 `bun.lock`. Commit both files together — the hash is what makes the pin tamper-evident.
@@ -85,16 +91,16 @@ differently, use its own type-check and unit-test targets.
 
 ## Moving to a later release
 
-Re-run the two commands under [Wiring the dependency](#wiring-the-dependency) with the new
-version; `bun add` rewrites both `package.json` and `bun.lock`. Because the URL pins an immutable
-release asset there are no semver ranges: every upgrade is an explicit, reviewable diff, and
-nothing moves under the consumer without a commit.
+Re-run the commands under [Wiring the dependency](#wiring-the-dependency); `VERSION` picks up
+whatever release is newest, and `bun add` rewrites both `package.json` and `bun.lock`. Because the
+URL pins an immutable release asset there are no semver ranges: every upgrade is an explicit,
+reviewable diff, and nothing moves under the consumer without a commit.
 
 ## Failure modes worth knowing
 
 - Do not install the git tag (`bun add github:VilnaCRM-Org/ui-toolkit#v0.1.0`). The tag carries
-  source only — `build/` is gitignored and there is no `prepare` script — so the install yields a
-  package whose every entry point resolves to a missing file.
+  source only — `build/` is gitignored and there is no `prepare` script — so the install yields
+  a package whose every entry point resolves to a missing file.
 - Container and CI installs need network access to `objects.githubusercontent.com`, which is where
   release-asset downloads redirect. An allowlisted egress proxy has to permit it.
 - Never re-cut a release with an existing version number. The old `sha512` is pinned in every

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,16 @@ MUTATION_SHARD_TOTAL ?= 1
 MUTATION_SHARD_INDEX ?= 0
 MUTATION_REPORTS_DIR = reports/mutation
 
+# Release packaging. The tarball is written outside build/ on purpose: `files`
+# publishes build/, so packing into it would fold the previous release's archive
+# into the next one.
+PACKAGE_DIR = dist
+PACKAGE_VERIFIER = scripts/ci/verify-package-tarball.sh
+
 # Misc
 .DEFAULT_GOAL = help
 .RECIPEPREFIX +=
-.PHONY: help build lint lint-next lint-tsc lint-md format-check lint-test-structure git-hooks-install \
+.PHONY: help build package lint lint-next lint-tsc lint-md format-check lint-test-structure git-hooks-install \
 	storybook-start storybook-build generate-ts-doc test-e2e test-e2e-local \
 	test-unit test-integration copy-coverage test-mutation test-memory-leak test-visual \
 	lighthouse-desktop lighthouse-mobile install update playwright-install test-bats \
@@ -60,6 +66,22 @@ help:
 
 build: ## Build the project inside the docker container.
 	$(RUN_BUN) node ./build.config.mjs
+
+# Uses the long-running bun service rather than `run --rm`: the service has no
+# volume mount, so a throwaway container would take the tarball down with it.
+# Everything is produced inside the container, then copied back to the host.
+package: ## Build and copy the publishable npm tarball out of the running bun container.
+	@container_id=$$($(DOCKER_COMPOSE) ps -q bun); \
+	if [ -z "$$container_id" ]; then \
+		echo "bun service is not running; run 'make start-bun' first"; \
+		exit 1; \
+	fi; \
+	$(EXEC_BUN) sh -lc 'rm -rf $(PACKAGE_DIR) && mkdir -p $(PACKAGE_DIR)' \
+		&& $(EXEC_BUN) node ./build.config.mjs \
+		&& $(EXEC_BUN) npm pack --pack-destination $(PACKAGE_DIR) \
+		&& $(EXEC_BUN) sh $(PACKAGE_VERIFIER) $(PACKAGE_DIR) \
+		&& rm -rf ./$(PACKAGE_DIR) \
+		&& $(DOCKER_COMPOSE) cp bun:/app/$(PACKAGE_DIR) ./$(PACKAGE_DIR)
 
 lint: lint-next lint-tsc lint-md format-check lint-dep-ranges lint-test-structure lint-deps lint-metrics ## Run all linters inside the docker container.
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ package: ## Build and copy the publishable npm tarball out of the running bun co
 		echo "bun service is not running; run 'make start-bun' first"; \
 		exit 1; \
 	fi; \
-	$(EXEC_BUN) sh -lc 'rm -rf $(PACKAGE_DIR) && mkdir -p $(PACKAGE_DIR)' \
+	$(EXEC_BUN) sh -lc 'rm -rf $(PACKAGE_DIR) build && mkdir -p $(PACKAGE_DIR)' \
 		&& $(EXEC_BUN) node ./build.config.mjs \
 		&& $(EXEC_BUN) npm pack --pack-destination $(PACKAGE_DIR) \
 		&& $(EXEC_BUN) sh $(PACKAGE_VERIFIER) $(PACKAGE_DIR) \

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ When you add or change a public Make target, update `tests/bats/make-target-cove
 same change. Either add or adjust direct Bats coverage for uncovered shell behavior, or point the
 manifest at the pull-request workflow that already exercises the target.
 
+### Releases
+
+The library is not published to the public npm registry. Pushing to `main` runs the release
+workflow, which bumps the version, tags it, and attaches the packed
+`vilnacrm-ui-toolkit-<version>.tgz` to the GitHub release; `crm` and `website` depend on that
+asset URL directly. Reproduce the artifact locally with:
+
+```bash
+make start-bun
+make package
+```
+
+The tarball lands in `dist/`, and the recipe fails if it does not carry the entry points that
+`package.json` promises. [CONSUMING.md](CONSUMING.md) is the consumer-side brief: how `crm` and
+`website` pin a release, verify it, and move to a later one.
+
 ### Dependency graph hygiene
 
 A zero-tolerance [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) gate guards

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -90,8 +90,8 @@ esbuild
     minify: true,
     format: 'esm',
     outExtension: { '.js': '.mjs' },
-    // Externalize only peer dependencies — the consumer provides them. Swiper is a
-    // direct dependency (not a peer), so it and its carousel CSS must stay bundled
+    // Externalize only peer dependencies — the consumer provides them. Swiper is
+    // deliberately not a peer, so it and its carousel CSS must stay bundled
     // into build/index.css (exported as `@vilnacrm/ui-toolkit/styles.css`); blanket
     // `packages: 'external'` would drop those required styles from the library.
     external: [

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "ui-toolkit",
-      "dependencies": {
-        "swiper": "^14.0.6",
-      },
       "devDependencies": {
         "@apollo/client": "^4.2.7",
         "@babel/preset-react": "^8.0.1",
@@ -76,6 +73,7 @@
         "react-i18next": "^17.0.10",
         "semver": "^7.5.4",
         "storybook": "^10.4.2",
+        "swiper": "^14.0.6",
         "terser-webpack-plugin": "^5.3.10",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
@@ -88,11 +86,11 @@
         "@emotion/styled": "^11.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
-        "i18next": "^23.0.0",
+        "i18next": ">=23.0.0 <27.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.0.0",
-        "react-i18next": "^14.0.0",
+        "react-i18next": ">=14.0.0 <18.0.0",
       },
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,8 +54,14 @@ const devDependencyPatterns = [
 // the CRM's TextField/FormProvider allow-list for this repo.
 const propSpreadingExceptions = ['TextField', 'FormProvider', 'Button', 'Typography', 'UiInput'];
 
+// swiper is deliberately absent from build.config.mjs's `external` list, so esbuild
+// inlines it (and its carousel CSS) into the published bundle. It therefore lives in
+// devDependencies — consumers never resolve it — and the one module importing it is
+// spared the extraneous-dependency check rather than forcing a bogus runtime range.
+const bundledDependencyImporters = ['src/components/ui-card-list/card-swiper.tsx'];
+
 const importNoExtraneousDependenciesOptions = {
-  devDependencies: devDependencyPatterns,
+  devDependencies: [...devDependencyPatterns, ...bundledDependencyImporters],
   packageDir: [rootDir],
 };
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@vilnacrm/ui-toolkit",
   "version": "0.1.0",
   "packageManager": "bun@1.3.5",
-  "dependencies": {
-    "swiper": "^14.0.6"
-  },
   "devDependencies": {
     "@apollo/client": "^4.2.7",
     "@babel/preset-react": "^8.0.1",
@@ -74,6 +71,7 @@
     "react-i18next": "^17.0.10",
     "semver": "^7.5.4",
     "storybook": "^10.4.2",
+    "swiper": "^14.0.6",
     "terser-webpack-plugin": "^5.3.10",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
@@ -113,7 +111,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.0.0",
-    "i18next": "^23.0.0",
-    "react-i18next": "^14.0.0"
+    "i18next": ">=23.0.0 <27.0.0",
+    "react-i18next": ">=14.0.0 <18.0.0"
   }
 }

--- a/scripts/ci/verify-package-tarball.sh
+++ b/scripts/ci/verify-package-tarball.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+
+# Guards the release artifact against a silently empty build.
+#
+# `npm pack` succeeds even when build/ holds nothing: `files` simply matches no
+# paths and the tarball ships with only package.json and the docs. Such a package
+# installs cleanly, and every consumer then fails at import time because each
+# entry point in `exports` resolves to a file that is not there. Assert the paths
+# the manifest promises are really inside the archive before it is attached to a
+# GitHub release.
+
+set -eu
+
+package_dir="${1:?usage: verify-package-tarball.sh <package-dir>}"
+
+tarball=''
+for candidate in "$package_dir"/*.tgz; do
+  [ -f "$candidate" ] || continue
+  if [ -n "$tarball" ]; then
+    echo "expected exactly one tarball in $package_dir, found $tarball and $candidate" >&2
+    exit 1
+  fi
+  tarball="$candidate"
+done
+
+if [ -z "$tarball" ]; then
+  echo "no tarball found in $package_dir" >&2
+  exit 1
+fi
+
+contents="$(tar -tzf "$tarball")"
+
+# npm prefixes every archive member with `package/`.
+for required in \
+  package/package.json \
+  package/build/index.mjs \
+  package/build/index.d.ts \
+  package/build/index.css; do
+  if ! printf '%s\n' "$contents" | grep -qx -- "$required"; then
+    echo "$tarball is missing $required" >&2
+    exit 1
+  fi
+done
+
+echo "verified $tarball"

--- a/scripts/ci/verify-package-tarball.sh
+++ b/scripts/ci/verify-package-tarball.sh
@@ -36,7 +36,7 @@ for required in \
   package/build/index.mjs \
   package/build/index.d.ts \
   package/build/index.css; do
-  if ! printf '%s\n' "$contents" | grep -qx -- "$required"; then
+  if ! printf '%s\n' "$contents" | grep -qxF -- "$required"; then
     echo "$tarball is missing $required" >&2
     exit 1
   fi

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -45,3 +45,4 @@ test-mutation-shard	bats	tests/bats/makefile_targets.bats	Validated for the runn
 copy-mutation-report	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the copy-success branch.
 stage-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the host-to-container copy branch.
 merge-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated for the running-container and fresh-container branches of the merge gate.
+package	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the build, pack, verify, and copy-out branch.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -161,7 +161,7 @@ EOF
   reset_command_log
   run_make_target_with_env package FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
   [ "$status" -eq 0 ]
-  assert_log_contains 'docker compose exec -T bun sh -lc rm -rf dist && mkdir -p dist'
+  assert_log_contains 'docker compose exec -T bun sh -lc rm -rf dist build && mkdir -p dist'
   assert_log_contains 'docker compose exec -T bun node ./build.config.mjs'
   assert_log_contains 'docker compose exec -T bun npm pack --pack-destination dist'
   assert_log_contains 'docker compose exec -T bun sh scripts/ci/verify-package-tarball.sh dist'
@@ -185,6 +185,8 @@ EOF
     FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id \
     FAKE_DOCKER_FAILING_COMMAND='verify-package-tarball.sh'
   [ "$status" -ne 0 ]
+  assert_log_contains 'docker compose exec -T bun node ./build.config.mjs'
+  assert_log_contains 'docker compose exec -T bun npm pack --pack-destination dist'
   assert_log_not_contains 'docker compose cp bun:/app/dist ./dist'
 }
 

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -148,6 +148,46 @@ EOF
   assert_log_contains 'docker compose cp bun:/app/coverage ./coverage'
 }
 
+@test "package fails clearly when the bun service is not running" {
+  reset_command_log
+  run_make_target package
+  [ "$status" -ne 0 ]
+  assert_output_contains "bun service is not running; run 'make start-bun' first"
+  assert_log_contains 'docker compose ps -q bun'
+  assert_log_not_contains 'npm pack'
+}
+
+@test "package builds, packs, verifies and copies the tarball out of the bun container" {
+  reset_command_log
+  run_make_target_with_env package FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose exec -T bun sh -lc rm -rf dist && mkdir -p dist'
+  assert_log_contains 'docker compose exec -T bun node ./build.config.mjs'
+  assert_log_contains 'docker compose exec -T bun npm pack --pack-destination dist'
+  assert_log_contains 'docker compose exec -T bun sh scripts/ci/verify-package-tarball.sh dist'
+  assert_log_contains 'docker compose cp bun:/app/dist ./dist'
+  assert_log_not_contains 'docker compose run --rm'
+}
+
+@test "package stops at the first failing step instead of shipping a stale tarball" {
+  reset_command_log
+  run_make_target_with_env package \
+    FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id \
+    FAKE_DOCKER_FAILING_COMMAND='node ./build.config.mjs'
+  [ "$status" -ne 0 ]
+  assert_log_not_contains 'npm pack'
+  assert_log_not_contains 'docker compose cp bun:/app/dist ./dist'
+}
+
+@test "package does not attach an unverified tarball when verification fails" {
+  reset_command_log
+  run_make_target_with_env package \
+    FAKE_DOCKER_COMPOSE_BUN_ID=bun-service-id \
+    FAKE_DOCKER_FAILING_COMMAND='verify-package-tarball.sh'
+  [ "$status" -ne 0 ]
+  assert_log_not_contains 'docker compose cp bun:/app/dist ./dist'
+}
+
 @test "start-bun builds and starts only the bun service" {
   reset_command_log
   run_make_target start-bun

--- a/tests/bats/release_package_tarball.bats
+++ b/tests/bats/release_package_tarball.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+# Covers the release-artifact guard: the tarball attached to a GitHub release must
+# carry the built entry points that package.json promises, because a package whose
+# `exports` point at missing files installs cleanly and only fails in the consumer.
+
+load './test_helper.bash'
+
+VERIFY_SCRIPT() {
+  printf '%s' "$PROJECT_ROOT/scripts/ci/verify-package-tarball.sh"
+}
+
+# Write an npm-shaped tarball (every member under `package/`) holding exactly the
+# given paths, so a test can express what the archive is missing.
+make_tarball() {
+  local destination="$1"
+  shift
+
+  local staging="$BATS_TEST_TMPDIR/staging"
+  rm -rf "$staging"
+  mkdir -p "$staging/package"
+
+  local member
+  for member in "$@"; do
+    mkdir -p "$staging/package/$(dirname "$member")"
+    echo 'fixture' > "$staging/package/$member"
+  done
+
+  tar -czf "$destination" -C "$staging" package
+}
+
+setup() {
+  PACKAGE_DIR="$BATS_TEST_TMPDIR/dist"
+  mkdir -p "$PACKAGE_DIR"
+}
+
+@test "the tarball verifier exists and is executable" {
+  run test -x "$(VERIFY_SCRIPT)"
+  [ "$status" -eq 0 ]
+}
+
+@test "verifier accepts a tarball carrying every published entry point" {
+  make_tarball "$PACKAGE_DIR/ui-toolkit-1.0.0.tgz" \
+    package.json build/index.mjs build/index.d.ts build/index.css
+
+  run "$(VERIFY_SCRIPT)" "$PACKAGE_DIR"
+  [ "$status" -eq 0 ]
+  assert_output_contains 'verified'
+}
+
+@test "verifier rejects a tarball whose build output never made it in" {
+  make_tarball "$PACKAGE_DIR/ui-toolkit-1.0.0.tgz" package.json
+
+  run "$(VERIFY_SCRIPT)" "$PACKAGE_DIR"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'is missing package/build/index.mjs'
+}
+
+@test "verifier rejects a tarball missing only the type declarations" {
+  make_tarball "$PACKAGE_DIR/ui-toolkit-1.0.0.tgz" \
+    package.json build/index.mjs build/index.css
+
+  run "$(VERIFY_SCRIPT)" "$PACKAGE_DIR"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'is missing package/build/index.d.ts'
+}
+
+@test "verifier rejects a tarball missing only the stylesheet" {
+  make_tarball "$PACKAGE_DIR/ui-toolkit-1.0.0.tgz" \
+    package.json build/index.mjs build/index.d.ts
+
+  run "$(VERIFY_SCRIPT)" "$PACKAGE_DIR"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'is missing package/build/index.css'
+}
+
+@test "verifier fails when the package directory holds no tarball" {
+  run "$(VERIFY_SCRIPT)" "$PACKAGE_DIR"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'no tarball found in'
+}
+
+@test "verifier refuses to guess when several tarballs are present" {
+  make_tarball "$PACKAGE_DIR/ui-toolkit-1.0.0.tgz" \
+    package.json build/index.mjs build/index.d.ts build/index.css
+  make_tarball "$PACKAGE_DIR/ui-toolkit-1.1.0.tgz" \
+    package.json build/index.mjs build/index.d.ts build/index.css
+
+  run "$(VERIFY_SCRIPT)" "$PACKAGE_DIR"
+  [ "$status" -eq 1 ]
+  assert_output_contains 'expected exactly one tarball'
+}
+
+@test "verifier requires the package directory argument" {
+  run "$(VERIFY_SCRIPT)"
+  [ "$status" -ne 0 ]
+  assert_output_contains 'usage: verify-package-tarball.sh'
+}
+
+@test "the release workflow packs the tarball and attaches it to the release" {
+  local workflow="$PROJECT_ROOT/.github/workflows/autorelease.yml"
+
+  run grep -F 'make package' "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'make start-bun' "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'dist/*.tgz' "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "the packed tarball is never published from a tracked directory" {
+  run grep -Fx 'dist/' "$PROJECT_ROOT/.gitignore"
+  [ "$status" -eq 0 ]
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -20,6 +20,13 @@ create_docker_stub() {
 #!/usr/bin/env bash
 printf 'docker %s\n' "$*" >> "${COMMAND_LOG:?}"
 
+# Lets a test make one specific docker invocation fail, so recipes that chain
+# several container commands can be checked for aborting on the first failure.
+if [ -n "${FAKE_DOCKER_FAILING_COMMAND:-}" ] \
+  && printf '%s' "$*" | grep -qF -- "$FAKE_DOCKER_FAILING_COMMAND"; then
+  exit 1
+fi
+
 if [ "$1" = "compose" ] && [ "$2" = "ps" ] && [ "${3:-}" = "-q" ] && [ "${4:-}" = "bun" ]; then
   if [ -n "${FAKE_DOCKER_COMPOSE_BUN_ID:-}" ]; then
     printf '%s\n' "$FAKE_DOCKER_COMPOSE_BUN_ID"


### PR DESCRIPTION
## Why

`crm` and `website` need to consume `@vilnacrm/ui-toolkit` without publishing to the npm registry.
Depending on a GitHub tag does not work today: `main`/`module`/`types`/`exports` all point at
`build/`, which is gitignored, and `package.json` has no `prepare` script — so installing the tag
yields a package whose every entry point resolves to a missing file. Adding `prepare` would force
every consumer install to pull ~80 devDeps and run esbuild + tsc + API Extractor.

The repository is public, so attaching the packed artifact to the release we already cut solves it
with no token, `.npmrc` entry, or CI secret on either consumer.

## What changed

- **`make package`** — builds and `npm pack`s inside the running bun service, verifies the tarball,
  and copies it back to `dist/` on the host. It drives the long-running service rather than
  `run --rm` because the `bun` service has no volume mount, so a throwaway container would take the
  tarball down with it.
- **`scripts/ci/verify-package-tarball.sh`** — fails the build unless the archive really contains
  `package.json`, `build/index.mjs`, `build/index.d.ts` and `build/index.css`. `npm pack` succeeds
  even when the build emitted nothing, and that package installs cleanly and only breaks in the
  consumer.
- **`autorelease.yml`** — packs between the changelog and release steps (the changelog action bumps
  `package.json` in the working tree first, so the artifact carries the released version) and passes
  `files: dist/*.tgz` to the existing release action.
- **`CONSUMING.md`** — consumer-side brief for wiring `crm` and `website`, written to be handed to an
  agent working in those repos.
- Bats coverage for the new target and script, the `make-target-coverage.tsv` row, and a
  `FAKE_DOCKER_FAILING_COMMAND` stub hook so the recipe is proven to abort on the first failure
  rather than shipping a stale tarball.

## Verification

- `make start-bun && make package` → `dist/vilnacrm-ui-toolkit-0.1.0.tgz`, verifier passes.
- Installed that tarball into a scratch project with both npm and bun; `@vilnacrm/ui-toolkit`
  resolves to `build/index.mjs` and bun records the `sha512` integrity hash in `bun.lock`.
- Full Bats suite: 283 passing, 0 failing.
- `markdownlint` and `prettier --check` clean on the changed files.

## Note for the merger

This lands as `feat`, so conventional-changelog will cut `v0.2.0` on merge — the first release to
carry a tarball. Consumers can pin it immediately after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach the packed npm tarball of `@vilnacrm/ui-toolkit` to every GitHub release so `crm` and `website` can install without npm. Adds a daily release-asset monitor and hardens packaging to prevent stale or incomplete archives.

- **New Features**
  - Release workflow starts the bun env, runs `make package` after the version bump, uploads `dist/*.tgz`, then stops the env.
  - Tarball verifier ensures `package.json`, `build/index.mjs`, `build/index.d.ts`, and `build/index.css` are in the archive.
  - Scheduled `release-asset-check.yml` verifies the newest release ships the exact expected `.tgz` and the latest `autorelease.yml` run on `main` succeeded.
  - Peers widened: `i18next >=23 <27`, `react-i18next >=14 <18`. `swiper` moved to devDependency; it stays bundled. Lint gates adjusted.

- **Bug Fixes**
  - Packaging fails closed on stale or near-miss builds: `make package` clears `build/` alongside `dist/`, and the verifier uses fixed-string checks for required paths.
  - Release monitor tightened: requires the exact asset name derived from the tag, fails on non-404 API errors, and treats only a `success` run as healthy.

<sup>Written for commit 3fd6b4ec24acd1cfb5217278066f4026050cd197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

