### PR TITLE
ci(#87): enforce the commit convention in CI and a husky commit-msg hook

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,37 +25,32 @@ jobs:
       contents: read
 
     steps:
+      # The head commit rather than the default merge ref: this job only reads history, and a
+      # conflicted pull request has no merge ref, which would redden the gate for an unrelated
+      # reason. fetch-depth: 0 still brings the base branch in for the merge-base below.
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Detect runtime project files
-        id: project
-        run: |
-          if [[ -f package.json && -f bun.lock ]]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Skip commit convention checks
-        if: steps.project.outputs.present != 'true'
-        run: echo "Skipping commitlint because this bootstrap PR does not include the project runtime files yet."
-
+      # No bootstrap-skip guard here, unlike the other workflows: this gate must fail closed.
+      # A pull request that deletes package.json or bun.lock has to turn the check red rather
+      # than let its own commits through unlinted.
+      #
+      # --ignore-scripts keeps dependency lifecycle scripts out of CI. It also skips this
+      # package's own `prepare`, which is only wanted in a developer's clone: this job lints
+      # messages, it does not commit any.
       - name: Set up Bun
-        if: steps.project.outputs.present == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        if: steps.project.outputs.present == 'true'
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Lint the pull request commits
-        if: steps.project.outputs.present == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -63,12 +58,18 @@ jobs:
           set -euo pipefail
           merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
           echo "Linting commits in ${merge_base}..${HEAD_SHA}"
-          bun x commitlint --from "$merge_base" --to "$HEAD_SHA" --verbose
+          # The lockfile-resolved binary, not `bun x`, so no unpinned release is fetched.
+          ./node_modules/.bin/commitlint --from "$merge_base" --to "$HEAD_SHA" --verbose
 
-      # Merges are squash-only here and the squash header is the pull request title whenever
-      # the branch carries more than one commit, so the title is release-driving input.
+      # Merges are squash-only here, so the pull request title becomes the commit header on
+      # main -- with ` (#<number>)` appended by GitHub. Linting the title exactly as it will
+      # land is what makes header-max-length measure the real released header.
       - name: Lint the pull request title
-        if: steps.project.outputs.present == 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: printf '%s\n' "$PR_TITLE" | bun x commitlint --verbose
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "Linting the squash header this pull request would land:"
+          printf '%s (#%s)\n' "$PR_TITLE" "$PR_NUMBER"
+          printf '%s (#%s)\n' "$PR_TITLE" "$PR_NUMBER" | ./node_modules/.bin/commitlint --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,74 @@
+name: commit convention
+
+# No `branches:` filter on purpose. PRs in this repository are stacked onto each other's
+# feature branches, so a `branches: [main]` gate would never see them. `edited` is required
+# because retitling a pull request changes the header that squash-merge lands on main.
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect runtime project files
+        id: project
+        run: |
+          if [[ -f package.json && -f bun.lock ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip commit convention checks
+        if: steps.project.outputs.present != 'true'
+        run: echo "Skipping commitlint because this bootstrap PR does not include the project runtime files yet."
+
+      - name: Set up Bun
+        if: steps.project.outputs.present == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        if: steps.project.outputs.present == 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Lint the pull request commits
+        if: steps.project.outputs.present == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "Linting commits in ${merge_base}..${HEAD_SHA}"
+          bun x commitlint --from "$merge_base" --to "$HEAD_SHA" --verbose
+
+      # Merges are squash-only here and the squash header is the pull request title whenever
+      # the branch carries more than one commit, so the title is release-driving input.
+      - name: Lint the pull request title
+        if: steps.project.outputs.present == 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | bun x commitlint --verbose

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+bun x commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,9 +354,11 @@ Two layers run the same `commitlint.config.js`:
   in Docker, because git hooks live in your clone and the `bun` image is built without `.git`.
 - **In CI.** The `commit convention` workflow lints every commit the pull request adds, and the
   pull request **title**. Merges here are squash-only, so the title becomes the commit header on
-  `main` whenever a branch carries more than one commit — it is release-driving input, and the job
-  re-runs whenever the title is edited. The workflow deliberately has no `branches:` filter, so it
-  also covers pull requests stacked onto other feature branches.
+  `main` — it is release-driving input, and the job re-runs whenever the title is edited. The
+  title is linted with the `(#<number>)` suffix GitHub appends at merge, so the 100-character
+  limit applies to the header that actually lands. The workflow deliberately has no `branches:`
+  filter, so it also covers pull requests stacked onto other feature branches, and it has no
+  bootstrap-skip guard: deleting `package.json` turns it red rather than green.
 
 Check your work before pushing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,6 +302,73 @@ Don't forget to self-review to speed up the review process :zap:.
 
 Our commits are based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
+#### Commit header format
+
+The published version is generated from these headers: `autorelease.yml` feeds the commits merged
+into `main` to `TriPSs/conventional-changelog-action`, which decides the semver bump and writes
+`CHANGELOG.md`. A malformed header is therefore not a style problem — the action cannot parse it,
+silently discards it, and the change ships under the wrong version or under none at all.
+`commitlint.config.js` is the contract, and every header must match `<type>(#<issue>): <subject>`:
+
+- **type** — one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`,
+  `style`, `test`. Only `feat` raises the minor version; the rest stay a patch.
+- **scope** — the issue the change closes: `#87`, or `#24,#25` when one change closes several
+  stories. `deps` and `deps-dev` are reserved for Dependabot, which has no issue to cite.
+- **subject** — lower case, no trailing period. The whole header stays within 100 characters.
+
+Headers that pass:
+
+```bash
+git commit -m "feat(#87): enforce the commit convention in CI"
+git commit -m "fix(#74): guard against a nullish image source"
+git commit -m "feat(#24,#25): add the skeleton parity baseline"
+```
+
+Headers that fail: `Fix button` (no type, no scope), `feat: add a gate` (no issue),
+`feat(release): ship a tarball` (the scope is not an issue), `feat(#87): Add A Gate` (title case).
+
+The only exempt messages are the ones no contributor can rewrite: merge and revert commits, the
+`chore(release):` commit the release action makes, and the `Optimised images with
+calibre/image-actions` commit that `image-optimization.yml` pushes onto pull request branches.
+
+#### Breaking changes and the version bump
+
+Mark a breaking change in the header **and** in the body. The `!` marker documents it for readers;
+the `BREAKING CHANGE:` footer is what the release action turns into a major bump:
+
+```bash
+git commit -m "feat(#87)!: drop the legacy entry point" \
+  -m "BREAKING CHANGE: consumers must now import styles from @vilnacrm/ui-toolkit/styles.css."
+```
+
+Leaving the footer out ships a breaking change as a patch — the exact failure this convention
+exists to prevent.
+
+#### How the convention is enforced
+
+Two layers run the same `commitlint.config.js`:
+
+- **Locally.** `bun install` runs the `prepare` script, which installs Husky 9 and activates the
+  committed `.husky/commit-msg` hook; it rejects a bad header before the commit exists. Use
+  `make git-hooks-install` to (re)install the hooks on their own. Both run on the host rather than
+  in Docker, because git hooks live in your clone and the `bun` image is built without `.git`.
+- **In CI.** The `commit convention` workflow lints every commit the pull request adds, and the
+  pull request **title**. Merges here are squash-only, so the title becomes the commit header on
+  `main` whenever a branch carries more than one commit — it is release-driving input, and the job
+  re-runs whenever the title is edited. The workflow deliberately has no `branches:` filter, so it
+  also covers pull requests stacked onto other feature branches.
+
+Check your work before pushing:
+
+```bash
+bun x commitlint --from origin/main --to HEAD --verbose
+bun x commitlint --last
+```
+
+As with the mutation gate, a maintainer must add the `commitlint` job under
+**Settings → Branches → Branch protection rules** for it to block a merge; until then it reports
+without gating.
+
 ### Docker base-image policy (Alpine)
 
 Every Dockerfile must use an Alpine-based image wherever an Alpine variant exists, for a

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
       g++=14.2.0-r6 \
       jq=1.8.1-r0 \
       make=4.4.1-r3 \
-      nodejs=22.23.0-r0 \
+      nodejs=22.23.2-r0 \
       npm=11.6.4-r0 \
       procps-ng=4.0.4-r3 \
       python3=3.12.13-r0 \

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,11 @@ lint-metrics-run: ## Evaluate metrics policy (run inside rca container via make 
 	export METRICS_POLICY_SCHEMA=config/metrics-policy.schema.json; \
 	sh scripts/lint-metrics.sh
 
-git-hooks-install: ## Install git hooks.
-	$(BUN_X) husky install
+# Host-side on purpose: the bun image bakes the repo without .git (.dockerignore) and has no
+# bind mount, so hooks written inside a container are thrown away with it. Husky 9 dropped the
+# `install` subcommand; `bun install` runs this same command through package.json's `prepare`.
+git-hooks-install: ## Install the Husky git hooks in this clone (host, not Docker).
+	bun x husky
 
 storybook-start: ## Start Storybook inside the docker container.
 	$(BUN_X) storybook dev -p 6006

--- a/agents.md
+++ b/agents.md
@@ -157,4 +157,7 @@ A change to tests is done only when every statement below is true.
   alone, and keyboard, focus, and accessibility-visible behavior are asserted where the UI
   changed.
 - The relevant test commands above were run and passed, including `make lint`.
-- Commits follow Conventional Commits.
+- Commits follow Conventional Commits: `<type>(#<issue>): <subject>`, enforced by the
+  `.husky/commit-msg` hook and the `commit convention` workflow. The pull request title follows
+  the same rule, because squash-merge lands it on `main` as the release-driving header. See
+  [CONTRIBUTING.md](CONTRIBUTING.md) for the full format and the breaking-change footer.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -41,9 +41,13 @@ const HEADER_HINT = [
 // force-push that re-triggers the action, so the gate has to let it through.
 const IMAGE_ACTIONS_HEADER = 'Optimised images with calibre/image-actions';
 
+// Matched on the whole first line, not as a prefix, so the exemption cannot be borrowed by a
+// header that merely starts with it.
+const isImageActionsCommit = message => message.split('\n')[0].trimEnd() === IMAGE_ACTIONS_HEADER;
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [message => message.startsWith(IMAGE_ACTIONS_HEADER)],
+  ignores: [isImageActionsCommit],
   rules: {
     'check-task-number-rule': [2, 'always'],
   },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,19 +1,56 @@
+// The release version is derived from these headers by
+// TriPSs/conventional-changelog-action (.github/workflows/autorelease.yml), so the header
+// shape is a semver contract rather than a style preference. Keep this file self-contained:
+// Dockerfile.playwright copies it on its own, without the rest of the repository.
+const TYPES = [
+  'build',
+  'chore',
+  'ci',
+  'docs',
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+];
+
+// Human-authored work is traceable to a GitHub issue: `#12`, or `#12,#13` when one change
+// closes several stories.
+const TASK_SCOPE = '#\\d+(?:,\\s*#\\d+)*';
+
+// Dependabot writes its own headers and has no issue to reference.
+const AUTOMATION_SCOPES = ['deps', 'deps-dev'];
+
+// `!` before the colon is the Conventional Commits breaking-change marker, which the release
+// action turns into a major bump — it has to be spellable.
+const HEADER_PATTERN = new RegExp(
+  `^(?:${TYPES.join('|')})\\((?:${TASK_SCOPE}|${AUTOMATION_SCOPES.join('|')})\\)!?:\\s.+$`
+);
+
+const HEADER_HINT = [
+  'header must be `<type>(#<issue>): <subject>`',
+  `type: ${TYPES.join(', ')}`,
+  `scope: #12, #12,#13, or ${AUTOMATION_SCOPES.join('/')} for Dependabot`,
+  'breaking change: `<type>(#<issue>)!: <subject>`',
+].join(' — ');
+
+// image-optimization.yml grants calibreapp/image-actions `contents: write` and it pushes this
+// exact header onto the pull request branch. No contributor can rewrite it without a
+// force-push that re-triggers the action, so the gate has to let it through.
+const IMAGE_ACTIONS_HEADER = 'Optimised images with calibre/image-actions';
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  ignores: [message => message.startsWith(IMAGE_ACTIONS_HEADER)],
   rules: {
     'check-task-number-rule': [2, 'always'],
   },
   plugins: [
     {
       rules: {
-        'check-task-number-rule': data => {
-          const list = 'build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test';
-
-          const regexp = new RegExp(`^(${list})\\(#\\d+\\):\\s.+$`);
-          const correctCommit = regexp.test(data.header);
-
-          return [correctCommit, `your task number incorrect (${list}(#1))`];
-        },
+        'check-task-number-rule': data => [HEADER_PATTERN.test(data.header), HEADER_HINT],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@vilnacrm/ui-toolkit",
   "version": "0.1.0",
   "packageManager": "bun@1.3.5",
+  "scripts": {
+    "prepare": "husky"
+  },
   "dependencies": {
     "swiper": "^14.0.6"
   },

--- a/tests/bats/commit_convention_contract.bats
+++ b/tests/bats/commit_convention_contract.bats
@@ -58,6 +58,45 @@ CONFIG="$PROJECT_ROOT/commitlint.config.js"
   [ "$status" -eq 0 ]
 }
 
+@test "the pull request title is linted with the suffix squash-merge appends" {
+  # GitHub lands `<title> (#<number>)`, so linting the bare title would measure
+  # header-max-length seven characters short of the header that actually reaches main.
+  run grep -F 'PR_NUMBER' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+
+  run grep -F '(#%s)' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow checks out the pull request head commit" {
+  # Not the merge ref: a conflicted pull request has none, and the gate must not go red for
+  # an unrelated reason.
+  run grep -F 'ref: ${{ github.event.pull_request.head.sha }}' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow fails closed instead of skipping itself" {
+  # Every other workflow here carries a bootstrap-skip guard that turns a missing package.json
+  # into a green run. This gate must not: a pull request deleting the policy inputs has to
+  # turn the check red rather than pass its own commits through unlinted.
+  run grep -F 'outputs.present' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
+@test "the commitlint workflow installs without running lifecycle scripts" {
+  run grep -F 'bun install --frozen-lockfile --ignore-scripts' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow runs the lockfile-resolved commitlint binary" {
+  # `bun x commitlint` would fetch an unpinned release when the package is absent.
+  run grep -F './node_modules/.bin/commitlint' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+
+  run grep -E '(bun|np)x commitlint' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
 @test "the commitlint workflow re-runs when a pull request is retitled" {
   run grep -E '^\s+- edited$' "$WORKFLOW"
   [ "$status" -eq 0 ]

--- a/tests/bats/commit_convention_contract.bats
+++ b/tests/bats/commit_convention_contract.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+# The release version is derived from commit headers by autorelease.yml, so the wiring that
+# validates those headers -- the husky commit-msg hook and the commitlint workflow -- is a
+# release contract. These tests lock the wiring itself; commit_message_policy.test.ts locks
+# which headers the rule accepts.
+
+load './test_helper.bash'
+
+HOOK="$PROJECT_ROOT/.husky/commit-msg"
+WORKFLOW="$PROJECT_ROOT/.github/workflows/commitlint.yml"
+CONFIG="$PROJECT_ROOT/commitlint.config.js"
+
+@test "the commit-msg hook is committed and runs commitlint against the edited message" {
+  [ -f "$HOOK" ]
+
+  run grep -F 'commitlint --edit "$1"' "$HOOK"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commit-msg hook carries no husky 8 bootstrap lines" {
+  # Husky 9 sources its own shim from .husky/_; these two lines are deprecated and fail in v10.
+  run grep -F 'husky.sh' "$HOOK"
+  [ "$status" -ne 0 ]
+
+  run grep -F '#!/usr/bin/env sh' "$HOOK"
+  [ "$status" -ne 0 ]
+}
+
+@test "package.json installs the hook through husky 9's prepare lifecycle" {
+  run jq -er '.scripts.prepare' "$PROJECT_ROOT/package.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "husky" ]
+
+  run jq -er '.devDependencies.husky' "$PROJECT_ROOT/package.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "the husky-generated shim directory keeps itself out of version control" {
+  # `husky` regenerates .husky/_ on every install and writes a `*` .gitignore into it. If that
+  # ever stops happening the generated shims would start landing in commits.
+  if [ -d "$PROJECT_ROOT/.husky/_" ]; then
+    run cat "$PROJECT_ROOT/.husky/_/.gitignore"
+    [ "$status" -eq 0 ]
+    [ "$output" = "*" ]
+  fi
+}
+
+@test "the commitlint workflow lints both the commit range and the pull request title" {
+  [ -f "$WORKFLOW" ]
+
+  # Squash-merge lands the pull request title on main whenever the branch has more than one
+  # commit, so the title is release-driving input and has to be linted alongside the commits.
+  run grep -F 'commitlint --from' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'PR_TITLE' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow re-runs when a pull request is retitled" {
+  run grep -E '^\s+- edited$' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow is not restricted to pull requests targeting main" {
+  # Pull requests here are stacked onto each other's feature branches. A `branches: [main]`
+  # filter would skip every one of them.
+  run grep -E '^\s+branches:' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
+@test "the commitlint workflow fetches enough history to resolve the merge base" {
+  run grep -F 'fetch-depth: 0' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'git merge-base' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow pins every action to an immutable commit SHA" {
+  local total pinned
+
+  total="$(grep -cE '^[[:space:]]+uses:' "$WORKFLOW")"
+  pinned="$(grep -cE '^[[:space:]]+uses: [^@]+@[0-9a-f]{40}( #.*)?$' "$WORKFLOW")"
+
+  [ "$total" -gt 0 ]
+  [ "$total" -eq "$pinned" ]
+}
+
+@test "the commitlint workflow runs read-only under a job timeout" {
+  run grep -F 'permissions: {}' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'contents: read' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'contents: write' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+
+  run grep -E '^\s+timeout-minutes: [0-9]+$' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "the commitlint workflow passes untrusted pull request input through env, not run" {
+  # A pull request title expanded straight into a run block is a script-injection sink: the
+  # title is attacker-controlled. It has to reach the shell as an environment variable.
+  run grep -F 'github.event.pull_request.title' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR_TITLE:"* ]]
+
+  run grep -F '"$PR_TITLE"' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "commitlint keeps the conventional-commits ruleset and the task-number rule at error level" {
+  run grep -F "extends: ['@commitlint/config-conventional']" "$CONFIG"
+  [ "$status" -eq 0 ]
+
+  run grep -F "'check-task-number-rule': [2, 'always']" "$CONFIG"
+  [ "$status" -eq 0 ]
+}
+
+@test "the Makefile git-hooks target matches husky 9 semantics" {
+  run grep -A 1 '^git-hooks-install:' "$PROJECT_ROOT/Makefile"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bun x husky"* ]]
+  [[ "$output" != *"husky install"* ]]
+}
+
+@test "CONTRIBUTING documents the commit header format and its semver linkage" {
+  run grep -F 'commitlint' "$PROJECT_ROOT/CONTRIBUTING.md"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'git-hooks-install' "$PROJECT_ROOT/CONTRIBUTING.md"
+  [ "$status" -eq 0 ]
+}

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -5,7 +5,7 @@ copy-coverage	bats	tests/bats/makefile_targets.bats	Validated for the missing-co
 down	ci	.github/workflows/static-testing.yml	Executed directly by multiple pull-request workflows that tear down the Docker environment.
 format-check	ci	.github/workflows/static-testing.yml	Executed directly by the static testing workflow.
 generate-ts-doc	bats	tests/bats/makefile_targets.bats	Validated as the API Extractor documentation entrypoint.
-git-hooks-install	bats	tests/bats/makefile_targets.bats	Validated as the Husky installation command.
+git-hooks-install	bats	tests/bats/makefile_targets.bats	Validated as the host-side Husky 9 hook installer, with no deprecated install subcommand.
 help	bats	tests/bats/makefile_targets.bats	Validated through the help output contract and `test-bats` discoverability.
 install	bats	tests/bats/makefile_targets.bats	Validated as the Bun dependency install entrypoint used before browser-style jobs.
 lighthouse-desktop	bats	tests/bats/makefile_targets.bats	Validated as the desktop Lighthouse shell entrypoint.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -25,7 +25,6 @@ setup() {
   done <<'EOF'
 build|docker compose run --rm bun node ./build.config.mjs|
 install|docker compose run --rm bun bun install --frozen-lockfile|
-git-hooks-install|docker compose run --rm bun bun x husky install|
 storybook-start|docker compose run --rm bun bun x storybook dev -p 6006|
 storybook-build|docker compose run --rm bun bun x storybook build|
 generate-ts-doc|docker compose run --rm bun bun x api-extractor run --local --verbose|
@@ -41,6 +40,21 @@ build-k6-docker|docker build -t k6 -f ./tests/load/Dockerfile .|
 lighthouse-desktop|docker compose run --rm --entrypoint sh bun -lc bun x storybook build|bun x lhci autorun --collect.settings.preset=desktop
 lighthouse-mobile|docker compose run --rm --entrypoint sh bun -lc bun x storybook build|bun x lhci autorun --collect.settings.formFactor=mobile
 EOF
+}
+
+@test "git-hooks-install runs husky 9 on the host, not inside the bun container" {
+  reset_command_log
+  run_make_target git-hooks-install
+  [ "$status" -eq 0 ]
+
+  # Husky must write .husky/_ and core.hooksPath into the developer's own clone. The bun
+  # image bakes the repository without .git and is not bind-mounted, so a containerised run
+  # would silently no-op.
+  assert_log_contains 'bun x husky'
+  assert_log_not_contains 'docker compose run --rm bun bun x husky'
+
+  # `husky install` is the Husky 8 form; Husky 9 deprecates it and Husky 10 removes it.
+  assert_log_not_contains 'husky install'
 }
 
 @test "run-storybook-playwright preserves the shared docker compose flow" {

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -46,9 +46,20 @@ EOF
   chmod +x "$STUB_BIN_DIR/docker"
 }
 
+create_bun_stub() {
+  cat > "$STUB_BIN_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+printf 'bun %s\n' "$*" >> "${COMMAND_LOG:?}"
+exit 0
+EOF
+
+  chmod +x "$STUB_BIN_DIR/bun"
+}
+
 setup_makefile_test_env() {
   setup_stub_dir
   create_docker_stub
+  create_bun_stub
 
   export MAKEFILE_SANDBOX="$BATS_TEST_TMPDIR/makefile-sandbox"
   mkdir -p "$MAKEFILE_SANDBOX"

--- a/tests/unit/config/commit-message-policy.test.ts
+++ b/tests/unit/config/commit-message-policy.test.ts
@@ -12,6 +12,22 @@ const explain = (header: string): string => String(taskNumberRule({ header })[1]
 const ignoresMessage = (message: string): boolean =>
   commitlintConfig.ignores.some(predicate => predicate(message));
 
+// The single source of truth for the tests below: every type here must be accepted by the rule
+// AND named in the failure hint, so the two can never drift apart or silently drop an entry.
+const ACCEPTED_TYPES = [
+  'build',
+  'chore',
+  'ci',
+  'docs',
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+];
+
 describe('commit header policy', () => {
   describe('accepted headers', () => {
     it.each([
@@ -28,12 +44,9 @@ describe('commit header policy', () => {
       expect(accepts(header)).toBe(true);
     });
 
-    it.each(['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'style', 'test'])(
-      'accepts the %s type',
-      type => {
-        expect(accepts(`${type}(#87): a subject`)).toBe(true);
-      }
-    );
+    it.each(ACCEPTED_TYPES)('accepts the %s type', type => {
+      expect(accepts(`${type}(#87): a subject`)).toBe(true);
+    });
   });
 
   describe('rejected headers', () => {
@@ -67,19 +80,7 @@ describe('commit header policy', () => {
     it('names every accepted type so the message never drifts from the rule', () => {
       const hint = explain('Fix button');
 
-      [
-        'build',
-        'chore',
-        'ci',
-        'docs',
-        'feat',
-        'fix',
-        'perf',
-        'refactor',
-        'revert',
-        'style',
-        'test',
-      ].forEach(type => {
+      ACCEPTED_TYPES.forEach(type => {
         expect(hint).toContain(type);
       });
     });

--- a/tests/unit/config/commit-message-policy.test.ts
+++ b/tests/unit/config/commit-message-policy.test.ts
@@ -103,6 +103,9 @@ describe('ignored messages', () => {
     'Fix button',
     'Optimised images by hand',
     'chore: optimise images with calibre/image-actions',
+    // The exemption is matched on the whole first line, so it cannot be borrowed as a prefix.
+    'Optimised images with calibre/image-actions and quietly drop the tests',
+    ' Optimised images with calibre/image-actions',
   ])('does not ignore %p', message => {
     expect(ignoresMessage(message)).toBe(false);
   });

--- a/tests/unit/config/commit-message-policy.test.ts
+++ b/tests/unit/config/commit-message-policy.test.ts
@@ -1,0 +1,119 @@
+import commitlintConfig from '../../../commitlint.config';
+
+// The release version is derived from commit headers by TriPSs/conventional-changelog-action
+// (.github/workflows/autorelease.yml). These cases are the shapes the repository's own
+// contributors and bots actually produce, so a change here changes what can be released.
+
+const taskNumberRule = commitlintConfig.plugins[0].rules['check-task-number-rule'];
+
+const accepts = (header: string): boolean => taskNumberRule({ header })[0] === true;
+const explain = (header: string): string => String(taskNumberRule({ header })[1]);
+
+const ignoresMessage = (message: string): boolean =>
+  commitlintConfig.ignores.some(predicate => predicate(message));
+
+describe('commit header policy', () => {
+  describe('accepted headers', () => {
+    it.each([
+      ['a single issue reference', 'feat(#87): add the commitlint gate'],
+      ['a fix', 'fix(#74): guard against a nullish src'],
+      ['several issues closed at once', 'feat(#24,#25,#26): epic 4 skeleton parity'],
+      ['several issues written with spaces', 'feat(#24, #25): epic 4 skeleton parity'],
+      ['a breaking change marker', 'feat(#87)!: drop the legacy entry point'],
+      ['a breaking change across issues', 'refactor(#24,#25)!: collapse the barrels'],
+      ['a Dependabot production bump', 'feat(deps): bump the all-deps group with 30 updates'],
+      ['a Dependabot development bump', 'chore(deps-dev): bump the all-deps group'],
+      ['the squash suffix GitHub appends', 'feat(#87): add the commitlint gate (#128)'],
+    ])('accepts %s', (_label, header) => {
+      expect(accepts(header)).toBe(true);
+    });
+
+    it.each(['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'style', 'test'])(
+      'accepts the %s type',
+      type => {
+        expect(accepts(`${type}(#87): a subject`)).toBe(true);
+      }
+    );
+  });
+
+  describe('rejected headers', () => {
+    it.each([
+      ['free-form prose', 'Fix button'],
+      ['a missing scope', 'feat: add the commitlint gate'],
+      ['an empty scope', 'feat(): add the commitlint gate'],
+      ['a scope with no issue number', 'feat(#): add the commitlint gate'],
+      ['an arbitrary word scope', 'feat(release): attach the packed npm tarball'],
+      ['an unknown type', 'wip(#87): add the commitlint gate'],
+      ['a type outside the enum', 'specs(#6): plan the toolkit completion'],
+      ['a missing space after the colon', 'feat(#87):add the commitlint gate'],
+      ['a missing subject', 'feat(#87): '],
+      ['the legacy stack prefix', '[Stack 4/4] shared parity layer'],
+      ['a trailing bang outside the scope', 'feat!(#87): drop the legacy entry point'],
+      ['a bare issue number without a type', '#87: add the commitlint gate'],
+    ])('rejects %s', (_label, header) => {
+      expect(accepts(header)).toBe(false);
+    });
+
+    it('rejects an empty header', () => {
+      expect(accepts('')).toBe(false);
+    });
+  });
+
+  describe('the failure hint', () => {
+    it('shows the expected header shape', () => {
+      expect(explain('Fix button')).toContain('<type>(#<issue>): <subject>');
+    });
+
+    it('names every accepted type so the message never drifts from the rule', () => {
+      const hint = explain('Fix button');
+
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+      ].forEach(type => {
+        expect(hint).toContain(type);
+      });
+    });
+
+    it('documents the breaking-change marker', () => {
+      expect(explain('Fix button')).toContain('<type>(#<issue>)!: <subject>');
+    });
+  });
+});
+
+describe('ignored messages', () => {
+  it('ignores the image-actions header that contributors cannot rewrite', () => {
+    expect(ignoresMessage('Optimised images with calibre/image-actions')).toBe(true);
+  });
+
+  it('ignores the image-actions header when a body follows it', () => {
+    expect(ignoresMessage('Optimised images with calibre/image-actions\n\nsome body')).toBe(true);
+  });
+
+  it.each([
+    'Fix button',
+    'Optimised images by hand',
+    'chore: optimise images with calibre/image-actions',
+  ])('does not ignore %p', message => {
+    expect(ignoresMessage(message)).toBe(false);
+  });
+});
+
+describe('the conventional-commits ruleset', () => {
+  it('still extends config-conventional, which supplies type-enum and subject rules', () => {
+    expect(commitlintConfig.extends).toEqual(['@commitlint/config-conventional']);
+  });
+
+  it('keeps the task-number rule at error severity', () => {
+    expect(commitlintConfig.rules['check-task-number-rule']).toEqual([2, 'always']);
+  });
+});


### PR DESCRIPTION
## Description

Closes #87.

`commitlint.config.js` existed, `@commitlint/cli` and `husky` were installed — and nothing ever
ran them. `package.json` had no `scripts` field, so husky's `prepare` never fired; no `.husky/`
directory was committed; `make git-hooks-install` ran the Husky 8 `install` subcommand *inside the
bun container*, which has no `.git` and no bind mount, so it was a silent no-op; and
`grep -rn commitlint .github/workflows/` returned nothing. The semver bump derived by
`TriPSs/conventional-changelog-action` rested entirely on maintainer discipline.

This wires enforcement at both ends and reconciles the rule with the headers this repository
actually produces.

### CI gate — `.github/workflows/commitlint.yml`

- Lints **every commit the pull request adds** (`--from $(git merge-base base head) --to head`)
  and the **pull request title**, with the ` (#N)` suffix GitHub appends at merge, so
  `header-max-length` measures the header that actually lands. Merges here are squash-only with
  `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so the title is release-driving input.
- **Fails closed.** Unlike the other workflows it carries no bootstrap-skip guard: those predate
  the runtime files, and here a PR deleting `package.json` would otherwise report a green skip
  while its own commits went unlinted.
- Re-runs on `edited`, so retitling a PR re-validates it.
- **No `branches:` filter.** PRs in this repo are stacked onto each other's feature branches; a
  `branches: [main]` gate would never see them. `image-optimization.yml` is the existing precedent.
- `fetch-depth: 0` (first workflow here to need history) and the merge base rather than a raw
  `origin/main` range — otherwise a stacked PR lints its whole 118-commit ancestry instead of its
  own 3 commits.
- Installs with `--ignore-scripts` and runs the lockfile-resolved `./node_modules/.bin/commitlint`
  rather than `bun x`, so no lifecycle script and no unpinned release runs in the gate.
- zizmor/actionlint-clean: actions pinned to full SHAs, `permissions: {}` + job `contents: read`,
  `timeout-minutes: 10`, `persist-credentials: false`, and the PR title reaches the shell through
  `env:` rather than `${{ }}` inside `run:` (script-injection sink).

### Local hook

- `package.json` gains `"scripts": { "prepare": "husky" }`; `.husky/commit-msg` is committed.
  Verified: `bun install --frozen-lockfile` runs `prepare`, sets `core.hooksPath`, and a
  `git commit -m "Fix button"` is rejected while `test(#87): …` is accepted. `bun.lock` is
  unchanged, so the `--frozen-lockfile` Docker build is unaffected (husky exits 0 with
  `.git can't be found` there, since `.dockerignore` excludes `.git`).
- `make git-hooks-install` now runs `bun x husky` on the **host** — Husky 9 dropped `install`, and
  hooks have to land in your clone, not in a throwaway container.

### Rule reconciliation

The rule as written could not have been switched on. Every change below is required for the gate
to be shippable; nothing semver-relevant was loosened.

| Header | Before | Now | Why |
| --- | --- | --- | --- |
| `feat(deps): …` / `chore(deps-dev): …` | ✗ | ✓ | `dependabot.yml` hardcodes `include: scope`, so bots can never cite an issue. This is also the header driving the pending `0.1.0 → 0.2.0` bump. |
| `feat(#24,#25,#26): …` | ✗ | ✓ | One change closing several stories — already used by #124. |
| `feat(#87)!: …` | ✗ | ✓ | The Conventional Commits breaking marker was unspellable, in a config whose stated purpose is catching breaking changes. |
| `Optimised images with calibre/image-actions` | ✗ | ignored | `image-optimization.yml` pushes this with `contents: write`; there are 11 on the current stack and no contributor can rewrite them without a force-push that re-triggers the action. |
| `Fix button`, `feat: …`, `feat(release): …`, title-case subjects | ✗ | ✗ | Unchanged. |

`@commitlint/config-conventional` is kept intact — `type-enum`, `subject-case`, `subject-empty`
and `header-max-length` all still apply.

## How Has This Been Tested?

- `tests/unit/config/commit-message-policy.test.ts` — 44 cases over the accepted/rejected header
  shapes, the ignore predicate, and the failure hint (which is asserted to name every accepted
  type, so it cannot drift from the rule).
- `tests/bats/commit_convention_contract.bats` — 19 cases locking the wiring: the committed hook
  and its lack of Husky 8 bootstrap lines, the `prepare` script, the host-side Makefile target,
  and the workflow's trigger types, missing `branches:` filter, `fetch-depth`, SHA pinning,
  permissions, timeout, and env-not-`run` handling of the title.
- `tests/bats/makefile_targets.bats` + `make-target-coverage.tsv` updated for the target's move
  off Docker; `test_helper.bash` gains a `bun` stub.
- Full local run: 659 Jest tests (100% coverage held), 284 Bats tests, `tsc`, `eslint`,
  `markdownlint`, `prettier --check`, `lint-test-structure`, `lint-dep-ranges` — all green.
- `bun x commitlint --last` passes on `main`'s HEAD (it did **not** before this change), and
  `bun x commitlint --from origin/main --to HEAD` passes on this branch.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Unrelated breakage this PR had to unblock

Alpine dropped `nodejs-22.23.0-r0` from v3.22 (it now ships `22.23.2-r0`), so **every**
docker-backed job in the repository has been failing at `apk add` since the last green run on
2026-07-29 — on `main` and on every open PR, not just this one. `Dockerfile` bumps that single
pin; `npm-11.6.4-r0` already resolves to the new nodejs, and `apk add -s` against the pinned base
image confirms both the base and chromium package sets resolve. Every other pin is still current.

## Follow-ups worth separate issues

1. **`commitlint` is advisory until a maintainer makes it required** (Settings → Branches). Same
   caveat the mutation gate carries; needs org-admin.
2. **`!` alone does not reach the release action.** The angular preset derives MAJOR only from a
   `BREAKING CHANGE:` body footer, so `feat(#12)!: …` without the footer still ships as a patch.
   CONTRIBUTING now tells contributors to write both; the real fix is switching the preset to
   `conventionalcommits` in `autorelease.yml`/`autoprerelease.yml`.
3. **`autorelease.yml` has failed on every push to `main` since 2026-06-24** — `git tag v0.2.0`
   collided with an existing tag, so the bump commit never landed and `package.json` is stuck at
   `0.1.0`. The blocking tag has since been deleted, so the next push should recover, but the gate
   here protects machinery that has not yet produced a release.
4. **`squash_merge_commit_message: COMMIT_MESSAGES`** concatenates every branch commit body into
   the squash body, so a stray `BREAKING CHANGE` (or even a line starting `breaking-change`)
   anywhere in a branch forces a major bump. Currently defended only by hand-clearing the body.
