### PR TITLE
feat(#98): aggregate make ci and make verify gate targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,41 @@ When you add or change a public Make target:
 - add or update Bats coverage for uncovered shell flows, or record the PR workflow that already
   exercises the target end to end
 
+### Prove it green before you push: `make ci` and `make verify`
+
+The merge bar is defined once, in the `Makefile`, and the pull-request workflows are thin
+wrappers around those same targets. Two aggregate targets replay it locally:
+
+```bash
+make ci       # fast pre-push set: lint, build, test-unit, test-integration, test-bats
+make verify   # the whole merge bar: make ci plus test-mutation, test-e2e, test-visual,
+              # test-memory-leak, lighthouse-desktop, and lighthouse-mobile
+```
+
+Run `make ci` before every push. Run `make verify` when you want the same proof a merge
+requires — a clean checkout with Docker goes from clone to fully-proven green with
+`make install && make verify`.
+
+Both targets run their gates in the listed order, stop at the first failure, exit non-zero,
+and finish with a summary table of `gate → pass / FAIL / skipped`, so a partial run can never
+be mistaken for a green one:
+
+| Gate               | Status    |
+| ------------------ | --------- |
+| `lint`             | `pass`    |
+| `build`            | `pass`    |
+| `test-unit`        | `FAIL`    |
+| `test-integration` | `skipped` |
+
+The gate sets live in the `CI_GATES` and `VERIFY_GATES` variables at the top of the `Makefile`.
+When you add a gate to a pull-request workflow, add it to `VERIFY_GATES` in the same change:
+`tests/bats/aggregate_gate_targets.bats` compares every `run: make …` line in
+`.github/workflows/` against the transitive dependency graph of `verify` and fails when a
+workflow runs a gate `make verify` cannot reach. Environment plumbing (`make start-bun`,
+`make down`, `make copy-coverage`, and the mutation report-shuffling targets) is exempt — those
+prove nothing on their own — and the sharded CI mutation targets map onto the single
+`test-mutation` gate that `make verify` runs.
+
 ### Dependency version ranges
 
 Every entry in `dependencies` and `devDependencies` of the root `package.json`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,7 @@ When you add or change a public Make target:
 
 ### Prove it green before you push: `make ci` and `make verify`
 
-The merge bar is defined once, in the `Makefile`, and the pull-request workflows are thin
-wrappers around those same targets. Two aggregate targets replay it locally:
+The merge bar is defined once, in the `Makefile`. Two aggregate targets replay it locally:
 
 ```bash
 make ci       # fast pre-push set: lint, build, test-unit, test-integration, test-bats
@@ -93,7 +92,10 @@ be mistaken for a green one:
 | `test-integration` | `skipped` |
 
 The gate sets live in the `CI_GATES` and `VERIFY_GATES` variables at the top of the `Makefile`.
-When you add a gate to a pull-request workflow, add it to `VERIFY_GATES` in the same change:
+The workflows do not call `make ci` or `make verify`; each job invokes the same underlying gate
+targets directly, alongside its own setup and teardown steps. Editing a gate set therefore does
+not reconfigure CI — the two definitions are held together by a test instead. When you add a
+gate to a pull-request workflow, add it to `VERIFY_GATES` in the same change:
 `tests/bats/aggregate_gate_targets.bats` compares every `run: make …` line in
 `.github/workflows/` against the transitive dependency graph of `verify` and fails when a
 workflow runs a gate `make verify` cannot reach. Environment plumbing (`make start-bun`,

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
       g++=14.2.0-r6 \
       jq=1.8.1-r0 \
       make=4.4.1-r3 \
-      nodejs=22.23.0-r0 \
+      nodejs=22.23.2-r0 \
       npm=11.6.4-r0 \
       procps-ng=4.0.4-r3 \
       python3=3.12.13-r0 \

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ MUTATION_SHARD_TOTAL ?= 1
 MUTATION_SHARD_INDEX ?= 0
 MUTATION_REPORTS_DIR = reports/mutation
 
-# Aggregate gate sets: the single source of truth for the merge bar. `ci` is the
-# fast pre-push set, `verify` is everything a merge requires. The pull-request
-# workflows stay thin wrappers around these same targets, and
-# tests/bats/aggregate_gate_targets.bats proves every gate a PR workflow runs is
-# reachable from `verify`, so local and CI definitions cannot drift.
+# Aggregate gate sets: the local definition of the merge bar. `ci` is the fast
+# pre-push set, `verify` is everything a merge requires. The pull-request workflows
+# invoke these same gate targets directly rather than calling ci/verify, so
+# tests/bats/aggregate_gate_targets.bats holds the two definitions together: it
+# fails when a workflow runs a gate `verify` cannot reach.
 CI_GATES = lint build test-unit test-integration test-bats
 VERIFY_EXTRA_GATES = test-mutation test-e2e test-visual test-memory-leak lighthouse-desktop lighthouse-mobile
 VERIFY_GATES = $(CI_GATES) $(VERIFY_EXTRA_GATES)

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,18 @@ MUTATION_SHARD_TOTAL ?= 1
 MUTATION_SHARD_INDEX ?= 0
 MUTATION_REPORTS_DIR = reports/mutation
 
+# Aggregate gate sets: the single source of truth for the merge bar. `ci` is the
+# fast pre-push set, `verify` is everything a merge requires. The pull-request
+# workflows stay thin wrappers around these same targets, and
+# tests/bats/aggregate_gate_targets.bats proves every gate a PR workflow runs is
+# reachable from `verify`, so local and CI definitions cannot drift.
+CI_GATES = lint build test-unit test-integration test-bats
+VERIFY_EXTRA_GATES = test-mutation test-e2e test-visual test-memory-leak lighthouse-desktop lighthouse-mobile
+VERIFY_GATES = $(CI_GATES) $(VERIFY_EXTRA_GATES)
+GATE_SET_NAME = gates
+GATE_SET =
+MAKE_GATE = $(MAKE) --no-print-directory
+
 # Misc
 .DEFAULT_GOAL = help
 .RECIPEPREFIX +=
@@ -37,7 +49,8 @@ MUTATION_REPORTS_DIR = reports/mutation
 	lighthouse-desktop lighthouse-mobile install update playwright-install test-bats \
 	up down sh ps logs new-logs start start-bun stop build-k6-docker load-tests run-storybook-playwright \
 	lint-dep-ranges lint-deps lint-metrics lint-metrics-run \
-	test-mutation-shard copy-mutation-report stage-mutation-reports merge-mutation-reports
+	test-mutation-shard copy-mutation-report stage-mutation-reports merge-mutation-reports \
+	ci verify run-gates
 
 PLAYWRIGHT_TEST_ARGS =
 
@@ -57,6 +70,38 @@ run-storybook-playwright:
 help:
 	@printf "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m\n"
 	@grep -E '^[-a-zA-Z0-9_\.\/]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-20s\033[0m %s\n", $$1, $$2}'
+
+ci: ## Run the fast pre-push gate set: lint, build, unit, integration, and Bats.
+	@$(MAKE) --no-print-directory run-gates GATE_SET_NAME=ci GATE_SET="$(CI_GATES)"
+
+verify: ## Run every gate a merge requires: make ci plus mutation, e2e, visual, memory-leak, and Lighthouse.
+	@$(MAKE) --no-print-directory run-gates GATE_SET_NAME=verify GATE_SET="$(VERIFY_GATES)"
+
+run-gates: ## Run each target in GATE_SET in order, then print a gate summary (used by ci and verify).
+	@test -n "$(GATE_SET)" || { echo "run-gates needs a non-empty GATE_SET; run 'make ci' or 'make verify'" >&2; exit 1; }
+	@name="$(GATE_SET_NAME)"; \
+		failed=""; \
+		summary=""; \
+		for gate in $(GATE_SET); do \
+			if [ -n "$$failed" ]; then \
+				summary="$$summary$$gate\tskipped\n"; \
+				continue; \
+			fi; \
+			printf '==> %s: make %s\n' "$$name" "$$gate"; \
+			if $(MAKE_GATE) $$gate; then \
+				summary="$$summary$$gate\tpass\n"; \
+			else \
+				summary="$$summary$$gate\tFAIL\n"; \
+				failed="$$gate"; \
+			fi; \
+		done; \
+		printf '\n%s gate summary\n' "$$name"; \
+		printf '%b' "$$summary" | awk -F'\t' '{ printf "  %-20s %s\n", $$1, $$2 }'; \
+		if [ -n "$$failed" ]; then \
+			printf '\n%s FAILED at gate: %s\n' "$$name" "$$failed" >&2; \
+			exit 1; \
+		fi; \
+		printf '\n%s PASSED: every gate is green\n' "$$name"
 
 build: ## Build the project inside the docker container.
 	$(RUN_BUN) node ./build.config.mjs

--- a/README.md
+++ b/README.md
@@ -25,18 +25,38 @@ bun install
 make help
 ```
 
+### Proving your branch green
+
+Two aggregate targets replay the merge bar locally, so you never have to reassemble it from
+the workflow YAMLs by hand:
+
+```bash
+make ci       # fast pre-push set: lint, build, unit, integration, Bats
+make verify   # everything a merge requires: make ci plus the heavy suites
+```
+
+Both run their gates in order, stop at the first failure, exit non-zero, and print a
+`gate → pass/FAIL/skipped` summary. A clean checkout with Docker goes from clone to
+fully-proven green with `make install && make verify`. `make verify` is the slow, complete
+proof (mutation, browser, and Lighthouse suites included); `make ci` is the one to run before
+every push. The Makefile is the single source of truth for the gate set — each pull-request
+workflow is a thin wrapper around the same targets, and `tests/bats/aggregate_gate_targets.bats`
+fails if a workflow ever runs a gate `make verify` cannot reach.
+
 Every pull request must pass the gating targets below; run the ones your change touches
 locally before pushing. See [agents.md](agents.md) for which test layer a given change needs.
 
-| Target                  | What it gates                                                |
-| ----------------------- | ------------------------------------------------------------ |
-| `make lint`             | ESLint, TypeScript, markdownlint, Prettier, dependency gates |
-| `make test-unit`        | Jest unit suite (components, hooks, pure logic) in jsdom     |
-| `make test-integration` | Jest composition suite: composed components, real children   |
-| `make test-e2e`         | Playwright behavior against a Storybook build                |
-| `make test-visual`      | Playwright visual-regression snapshots                       |
-| `make test-mutation`    | Stryker mutation-strength gate                               |
-| `make test-bats`        | Bats coverage of Makefile shell flows and their contracts    |
+| Target                  | What it gates                                                  |
+| ----------------------- | -------------------------------------------------------------- |
+| `make ci`               | Aggregate fast gate set — lint, build, unit, integration, Bats |
+| `make verify`           | Aggregate full merge bar — `make ci` plus the heavy suites     |
+| `make lint`             | ESLint, TypeScript, markdownlint, Prettier, dependency gates   |
+| `make test-unit`        | Jest unit suite (components, hooks, pure logic) in jsdom       |
+| `make test-integration` | Jest composition suite: composed components, real children     |
+| `make test-e2e`         | Playwright behavior against a Storybook build                  |
+| `make test-visual`      | Playwright visual-regression snapshots                         |
+| `make test-mutation`    | Stryker mutation-strength gate                                 |
+| `make test-bats`        | Bats coverage of Makefile shell flows and their contracts      |
 
 The `lint-metrics` target runs a `rust-code-analysis` complexity gate over `src/`. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the policy details and remediation guidance.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ Both run their gates in order, stop at the first failure, exit non-zero, and pri
 `gate → pass/FAIL/skipped` summary. A clean checkout with Docker goes from clone to
 fully-proven green with `make install && make verify`. `make verify` is the slow, complete
 proof (mutation, browser, and Lighthouse suites included); `make ci` is the one to run before
-every push. The Makefile is the single source of truth for the gate set — each pull-request
-workflow is a thin wrapper around the same targets, and `tests/bats/aggregate_gate_targets.bats`
-fails if a workflow ever runs a gate `make verify` cannot reach.
+every push. The pull-request workflows do not call `make ci` or `make verify` — they invoke the
+same underlying gate targets directly, alongside their own setup and teardown steps. What keeps
+the two definitions from drifting is `tests/bats/aggregate_gate_targets.bats`, which fails if a
+workflow ever runs a gate `make verify` cannot reach. Adding a gate to a workflow therefore also
+means adding it to `VERIFY_GATES`; editing the gate set alone does not reconfigure CI.
 
 Every pull request must pass the gating targets below; run the ones your change touches
 locally before pushing. See [agents.md](agents.md) for which test layer a given change needs.

--- a/agents.md
+++ b/agents.md
@@ -125,8 +125,14 @@ make test-visual           # Visual regression (for UI or styling changes)
 make lint                  # Full gate: ESLint, TypeScript, markdownlint, and format-check
 ```
 
-Run only the suites the change affects, but never skip a suite that does apply. If a
-deliberate, reviewed UI change makes visual baselines stale, regenerate them with
+Run only the suites the change affects, but never skip a suite that does apply. When you want
+the whole gate set instead of a hand-picked subset, use the aggregate targets — `make ci` for
+the fast pre-push set (lint, build, unit, integration, Bats) and `make verify` for the entire
+merge bar (`make ci` plus mutation, e2e, visual, memory-leak, and both Lighthouse form
+factors). Both fail fast and print a `gate → pass/FAIL/skipped` summary; a green `make verify`
+is the same proof a merge requires. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+If a deliberate, reviewed UI change makes visual baselines stale, regenerate them with
 `make test-visual PLAYWRIGHT_TEST_ARGS="--update-snapshots"` and review the diff before
 committing.
 

--- a/tests/bats/aggregate_gate_targets.bats
+++ b/tests/bats/aggregate_gate_targets.bats
@@ -134,9 +134,17 @@ verify_closure() {
 # heavily for multi-line shell. Inside a block, indentation greater than the `run:` key's
 # own indentation marks body lines; the first line at or below it ends the block.
 #
-# Within a command line, only a `make` at a command position — line start, or right after
-# a `;`, `&`, `|`, or `(` — is an invocation, so prose in a `# make sure ...` comment or an
-# `echo "... does not make ..."` message is never mistaken for one.
+# A command line is split on shell command separators (`;`, `&`, `|`, parentheses, and
+# quotes, so `sh -c 'make x'` puts the quoted body in its own segment). A segment counts as
+# an invocation when `make` is its first word, after any leading env assignments and command
+# wrappers (`sudo`, `env`, `time`, ...) and shell keywords are stripped — so `sudo make x`,
+# `FOO=bar make x`, and `cd sub && make x` are all caught.
+#
+# The bias here is deliberate: a missed invocation is silent drift, which is the failure this
+# contract exists to prevent, while a false positive fails loudly and gets fixed. What keeps
+# the widening honest is that prose can still never match — a trailing `# make sure ...`
+# comment is stripped, and in `echo "... does not make the work done"` the quoted segment
+# starts with its own first word, not `make`. Both shapes are pinned in the fixture test.
 pull_request_workflow_targets() {
   local workflows_dir="${1:-$PROJECT_ROOT/.github/workflows}"
   local workflow
@@ -146,13 +154,27 @@ pull_request_workflow_targets() {
     grep -qF 'pull_request:' "$workflow" || continue
 
     awk '
-      function emit_invocations(command,   target) {
-        command = "; " command
-        while (match(command, /[;&|(][ \t]*make[ \t]+[A-Za-z0-9_.*-]+/)) {
-          target = substr(command, RSTART, RLENGTH)
-          sub(/^[;&|(][ \t]*make[ \t]+/, "", target)
-          print target
-          command = substr(command, RSTART + RLENGTH)
+      BEGIN {
+        quote = sprintf("%c", 39)
+        separators = "[;&|()`\"" quote "]+"
+        command_prefixes = "^[ \t]*([A-Za-z_][A-Za-z0-9_]*=[^ \t]*" \
+          "|sudo|env|time|nice|command|exec|xargs|then|do|else)[ \t]+"
+      }
+
+      function emit_invocations(command,   count, i, segments, segment, target) {
+        sub(/(^|[ \t])#.*/, "", command)
+        count = split(command, segments, separators)
+
+        for (i = 1; i <= count; i++) {
+          segment = segments[i]
+          while (match(segment, command_prefixes)) {
+            segment = substr(segment, RSTART + RLENGTH)
+          }
+          if (match(segment, /^[ \t]*make[ \t]+[A-Za-z0-9_.*-]+/)) {
+            target = substr(segment, RSTART, RLENGTH)
+            sub(/^[ \t]*make[ \t]+/, "", target)
+            print target
+          }
         }
       }
 
@@ -321,6 +343,11 @@ jobs:
           make gate-block-scalar
           echo "a skip message does not make the work done"
           cd sub && make gate-chained
+          sudo make gate-sudo
+          env FOO=bar make gate-env
+          FOO=bar make gate-assign
+          sh -c 'make gate-sh-c'
+          if [ -f Makefile ]; then make gate-after-keyword; fi
       - name: matrix
         run: make gate-fanned-${{ matrix.formFactor }}
       - name: after the block
@@ -328,8 +355,9 @@ jobs:
 YAML
 
   run diff -u \
-    <(printf '%s\n' gate-after-block gate-block-scalar gate-chained 'gate-fanned-*' \
-      gate-from-yaml gate-list-item gate-plain-key | sort) \
+    <(printf '%s\n' gate-after-block gate-after-keyword gate-assign gate-block-scalar \
+      gate-chained gate-env 'gate-fanned-*' gate-from-yaml gate-list-item gate-plain-key \
+      gate-sh-c gate-sudo | sort) \
     <(pull_request_workflow_targets "$fixtures")
   [ "$status" -eq 0 ]
 }

--- a/tests/bats/aggregate_gate_targets.bats
+++ b/tests/bats/aggregate_gate_targets.bats
@@ -122,17 +122,22 @@ verify_closure() {
   printf '%s\n' $seen | sort -u
 }
 
-# Every `run: make <target>` a pull-request workflow executes. GitHub expressions such as
-# `${{ matrix.formFactor }}` are collapsed to `*` so a matrix-fanned target is matched as
-# the family it stands for instead of being silently dropped.
+# Every `run: make <target>` a pull-request workflow executes. Both GitHub workflow
+# extensions are scanned, so a future `.yaml` file cannot drop out of the reachability
+# guarantee unnoticed. GitHub expressions such as `${{ matrix.formFactor }}` are collapsed
+# to `*` so a matrix-fanned target is matched as the family it stands for instead of being
+# silently dropped, and `run:` is recognised both on its own line and as the `- run:` list
+# item form.
 pull_request_workflow_targets() {
+  local workflows_dir="${1:-$PROJECT_ROOT/.github/workflows}"
   local workflow
 
-  for workflow in "$PROJECT_ROOT"/.github/workflows/*.yml; do
+  for workflow in "$workflows_dir"/*.yml "$workflows_dir"/*.yaml; do
+    [ -f "$workflow" ] || continue
     grep -qF 'pull_request:' "$workflow" || continue
 
     sed -E 's/\$\{\{[^}]*\}\}/*/g' "$workflow" \
-      | sed -n -E 's/^[[:space:]]*run:[[:space:]]*make[[:space:]]+([A-Za-z0-9_.*-]+).*/\1/p'
+      | sed -n -E 's/^[[:space:]]*(-[[:space:]]+)?run:[[:space:]]*make[[:space:]]+([A-Za-z0-9_.*-]+).*/\2/p'
   done | sort -u
 }
 
@@ -246,6 +251,23 @@ gate_equivalent() {
   printf '%s\n' "$targets" | grep -qxF -- 'test-unit'
   printf '%s\n' "$targets" | grep -qxF -- 'test-mutation-shard'
   printf '%s\n' "$targets" | grep -qxF -- 'lighthouse-*'
+}
+
+@test "the workflow scanner reads both .yml and .yaml workflows and ignores non-PR ones" {
+  local fixtures="$BATS_TEST_TMPDIR/workflows"
+  mkdir -p "$fixtures"
+
+  printf 'on:\n  pull_request:\njobs:\n  a:\n    steps:\n      - run: make gate-from-yml\n' \
+    > "$fixtures/short.yml"
+  printf 'on:\n  pull_request:\njobs:\n  a:\n    steps:\n      - run: make gate-from-yaml\n' \
+    > "$fixtures/long.yaml"
+  printf 'on:\n  push:\njobs:\n  a:\n    steps:\n      - run: make gate-from-push\n' \
+    > "$fixtures/push-only.yml"
+
+  run diff -u \
+    <(printf '%s\n' gate-from-yaml gate-from-yml) \
+    <(pull_request_workflow_targets "$fixtures")
+  [ "$status" -eq 0 ]
 }
 
 @test "every gate a pull request workflow runs is reachable from make verify" {

--- a/tests/bats/aggregate_gate_targets.bats
+++ b/tests/bats/aggregate_gate_targets.bats
@@ -162,11 +162,14 @@ pull_request_workflow_targets() {
       }
 
       function emit_invocations(command,   count, i, segments, segment, target) {
-        sub(/(^|[ \t])#.*/, "", command)
         count = split(command, segments, separators)
 
         for (i = 1; i <= count; i++) {
           segment = segments[i]
+          # Per segment, not per line: splitting on quotes first means a `#` inside a
+          # quoted string can only truncate its own segment, never hide a later
+          # invocation such as `echo "color #ff0000"; make x`.
+          sub(/(^|[ \t])#.*/, "", segment)
           while (match(segment, command_prefixes)) {
             segment = substr(segment, RSTART + RLENGTH)
           }
@@ -346,8 +349,16 @@ jobs:
           sudo make gate-sudo
           env FOO=bar make gate-env
           FOO=bar make gate-assign
+          FIRST=1 SECOND=2 make gate-multi-assign
           sh -c 'make gate-sh-c'
-          if [ -f Makefile ]; then make gate-after-keyword; fi
+          time make gate-time
+          nice make gate-nice
+          command make gate-command
+          exec make gate-exec
+          echo x | xargs make gate-xargs
+          if [ -f Makefile ]; then make gate-after-then; else make gate-after-else; fi
+          for target in one; do make gate-after-do; done
+          echo "a hex colour #ff0000 inside quotes"; make gate-after-quoted-hash
       - name: matrix
         run: make gate-fanned-${{ matrix.formFactor }}
       - name: after the block
@@ -355,9 +366,10 @@ jobs:
 YAML
 
   run diff -u \
-    <(printf '%s\n' gate-after-block gate-after-keyword gate-assign gate-block-scalar \
-      gate-chained gate-env 'gate-fanned-*' gate-from-yaml gate-list-item gate-plain-key \
-      gate-sh-c gate-sudo | sort) \
+    <(printf '%s\n' gate-after-block gate-after-do gate-after-else gate-after-quoted-hash \
+      gate-after-then gate-assign gate-block-scalar gate-chained gate-command gate-env \
+      gate-exec 'gate-fanned-*' gate-from-yaml gate-list-item gate-multi-assign gate-nice \
+      gate-plain-key gate-sh-c gate-sudo gate-time gate-xargs | sort) \
     <(pull_request_workflow_targets "$fixtures")
   [ "$status" -eq 0 ]
 }

--- a/tests/bats/aggregate_gate_targets.bats
+++ b/tests/bats/aggregate_gate_targets.bats
@@ -126,8 +126,17 @@ verify_closure() {
 # extensions are scanned, so a future `.yaml` file cannot drop out of the reachability
 # guarantee unnoticed. GitHub expressions such as `${{ matrix.formFactor }}` are collapsed
 # to `*` so a matrix-fanned target is matched as the family it stands for instead of being
-# silently dropped, and `run:` is recognised both on its own line and as the `- run:` list
-# item form.
+# silently dropped.
+#
+# All three step forms count, because a gate that moves between them must not fall out of
+# the contract: `run: make x`, the `- run: make x` list-item form, and the block-scalar
+# form (`run: |` followed by indented command lines), which the workflows already use
+# heavily for multi-line shell. Inside a block, indentation greater than the `run:` key's
+# own indentation marks body lines; the first line at or below it ends the block.
+#
+# Within a command line, only a `make` at a command position — line start, or right after
+# a `;`, `&`, `|`, or `(` — is an invocation, so prose in a `# make sure ...` comment or an
+# `echo "... does not make ..."` message is never mistaken for one.
 pull_request_workflow_targets() {
   local workflows_dir="${1:-$PROJECT_ROOT/.github/workflows}"
   local workflow
@@ -136,8 +145,38 @@ pull_request_workflow_targets() {
     [ -f "$workflow" ] || continue
     grep -qF 'pull_request:' "$workflow" || continue
 
-    sed -E 's/\$\{\{[^}]*\}\}/*/g' "$workflow" \
-      | sed -n -E 's/^[[:space:]]*(-[[:space:]]+)?run:[[:space:]]*make[[:space:]]+([A-Za-z0-9_.*-]+).*/\2/p'
+    awk '
+      function emit_invocations(command,   target) {
+        command = "; " command
+        while (match(command, /[;&|(][ \t]*make[ \t]+[A-Za-z0-9_.*-]+/)) {
+          target = substr(command, RSTART, RLENGTH)
+          sub(/^[;&|(][ \t]*make[ \t]+/, "", target)
+          print target
+          command = substr(command, RSTART + RLENGTH)
+        }
+      }
+
+      { gsub(/\$\{\{[^}]*\}\}/, "*"); line = $0 }
+
+      in_block {
+        if (line ~ /^[ \t]*$/) { next }
+        match(line, /^[ \t]*/)
+        if (RLENGTH > block_indent) { emit_invocations(line); next }
+        in_block = 0
+      }
+
+      {
+        if (line ~ /^[ \t]*(-[ \t]+)?run:[ \t]*[|>][-+0-9]*[ \t]*$/) {
+          match(line, /^[ \t]*/)
+          block_indent = RLENGTH
+          in_block = 1
+          next
+        }
+        if (match(line, /^[ \t]*(-[ \t]+)?run:[ \t]*/)) {
+          emit_invocations(substr(line, RSTART + RLENGTH))
+        }
+      }
+    ' "$workflow"
   done | sort -u
 }
 
@@ -253,19 +292,44 @@ gate_equivalent() {
   printf '%s\n' "$targets" | grep -qxF -- 'lighthouse-*'
 }
 
-@test "the workflow scanner reads both .yml and .yaml workflows and ignores non-PR ones" {
+@test "the workflow scanner reads every step form, both file extensions, and only PR workflows" {
   local fixtures="$BATS_TEST_TMPDIR/workflows"
   mkdir -p "$fixtures"
 
-  printf 'on:\n  pull_request:\njobs:\n  a:\n    steps:\n      - run: make gate-from-yml\n' \
-    > "$fixtures/short.yml"
+  # Extensions: a workflow authored as .yaml must count too.
   printf 'on:\n  pull_request:\njobs:\n  a:\n    steps:\n      - run: make gate-from-yaml\n' \
     > "$fixtures/long.yaml"
+
+  # A push-only workflow is not part of the merge bar and must be ignored.
   printf 'on:\n  push:\njobs:\n  a:\n    steps:\n      - run: make gate-from-push\n' \
     > "$fixtures/push-only.yml"
 
+  # Step forms: list-item, plain key, block scalar (including a chained invocation),
+  # and a matrix-fanned target. Plus the two prose shapes that must NOT be picked up.
+  cat > "$fixtures/forms.yml" <<'YAML'
+on:
+  pull_request:
+jobs:
+  a:
+    steps:
+      - run: make gate-list-item
+      - name: plain key
+        run: make gate-plain-key ARG=value
+      - name: block scalar
+        run: |
+          # make sure the service is up before the gate runs
+          make gate-block-scalar
+          echo "a skip message does not make the work done"
+          cd sub && make gate-chained
+      - name: matrix
+        run: make gate-fanned-${{ matrix.formFactor }}
+      - name: after the block
+        run: make gate-after-block
+YAML
+
   run diff -u \
-    <(printf '%s\n' gate-from-yaml gate-from-yml) \
+    <(printf '%s\n' gate-after-block gate-block-scalar gate-chained 'gate-fanned-*' \
+      gate-from-yaml gate-list-item gate-plain-key | sort) \
     <(pull_request_workflow_targets "$fixtures")
   [ "$status" -eq 0 ]
 }

--- a/tests/bats/aggregate_gate_targets.bats
+++ b/tests/bats/aggregate_gate_targets.bats
@@ -1,0 +1,293 @@
+#!/usr/bin/env bats
+
+# Guards the aggregate gate targets (issue #98). `make ci` and `make verify` are the
+# repository's answer to "is my branch green?": one command that replays the merge bar
+# locally instead of hand-copying steps out of 20 workflow YAMLs. Three things must stay
+# true for that promise to hold:
+#
+#   1. Both targets run their gate set in order, fail fast, and exit non-zero.
+#   2. `verify` is a superset of `ci`, so the cheap set can never drift out of the full one.
+#   3. Every gate a pull-request workflow runs is reachable from `verify` — otherwise a
+#      green `make verify` would prove less than a green pull request.
+
+load './test_helper.bash'
+
+# Pull-request workflow targets that are environment plumbing rather than quality gates:
+# they boot, tear down, or move artifacts and assert nothing on their own. `make verify`
+# manages its own containers through each gate, so it never needs to invoke these.
+PLUMBING_TARGETS=(install start start-bun up down copy-coverage copy-mutation-report stage-mutation-reports)
+
+# Sharded CI equivalents of a single local gate. CI fans mutation testing across a matrix
+# and re-enforces the same Stryker break threshold once over the union of the shards;
+# `make verify` runs that identical gate unsharded in one process.
+GATE_EQUIVALENT_test_mutation_shard=test-mutation
+GATE_EQUIVALENT_merge_mutation_reports=test-mutation
+
+setup() {
+  setup_makefile_test_env
+  create_gate_make_stub
+}
+
+# A stand-in for the recursive `make <gate>` invocation, injected through the Makefile's
+# MAKE_GATE variable. It logs each gate it was asked to run and fails the gates named in
+# FAKE_FAILING_GATES, so the gate-runner's own control flow can be tested without running
+# the real Docker-backed suites.
+create_gate_make_stub() {
+  cat > "$STUB_BIN_DIR/gate-make" <<'EOF'
+#!/usr/bin/env bash
+printf 'gate-make %s\n' "$*" >> "${COMMAND_LOG:?}"
+
+for failing_gate in ${FAKE_FAILING_GATES:-}; do
+  if [ "$1" = "$failing_gate" ]; then
+    exit 1
+  fi
+done
+
+exit 0
+EOF
+
+  chmod +x "$STUB_BIN_DIR/gate-make"
+}
+
+run_gate_set() {
+  local target="$1"
+
+  run env \
+    PATH="$STUB_BIN_DIR:$PATH" \
+    COMMAND_LOG="$COMMAND_LOG" \
+    FAKE_FAILING_GATES="${FAKE_FAILING_GATES:-}" \
+    make -C "$MAKEFILE_SANDBOX" "$target" MAKE_GATE=gate-make
+}
+
+# The gates the stub was actually asked to run, in order.
+executed_gates() {
+  awk '$1 == "gate-make" { print $2 }' "$COMMAND_LOG"
+}
+
+assert_summary_row() {
+  assert_output_contains "$(printf '  %-20s %s' "$1" "$2")"
+}
+
+# Resolve a Makefile variable with real Make semantics (nested $(...) references included)
+# rather than re-implementing expansion in awk.
+makefile_variable() {
+  local printer="$BATS_TEST_TMPDIR/print.mk"
+
+  printf 'print-%%:\n\t@printf "%%s\\n" "$($*)"\n' > "$printer"
+  make --no-print-directory -C "$PROJECT_ROOT" -f Makefile -f "$printer" "print-$1"
+}
+
+# Every real target defined in the Makefile, excluding the dot-directives. Mirrors the
+# parsing used by target_coverage_contract.bats so every contract sees the same set.
+makefile_target_names() {
+  awk -F: '/^[A-Za-z0-9_.-]+:/ { if ($1 !~ /^\./) print $1 }' "$PROJECT_ROOT/Makefile" | sort -u
+}
+
+# The prerequisites of a target, with the trailing `## help text` stripped so a comment
+# word can never be mistaken for a dependency.
+target_prerequisites() {
+  awk -F: -v target="$1" '
+    $1 == target {
+      sub(/^[^:]*:/, "")
+      sub(/##.*/, "")
+      print
+    }
+  ' "$PROJECT_ROOT/Makefile"
+}
+
+# Every target `make verify` reaches, transitively: the gate list plus the prerequisites
+# each gate pulls in (this is what expands the `lint` aggregate into its eight linters).
+verify_closure() {
+  local known queue=() seen="" target token
+
+  known="$(makefile_target_names)"
+  read -r -a queue <<< "$(makefile_variable VERIFY_GATES)"
+
+  while [ "${#queue[@]}" -gt 0 ]; do
+    target="${queue[0]}"
+    queue=("${queue[@]:1}")
+
+    case " $seen " in
+      *" $target "*) continue ;;
+    esac
+    seen="$seen $target"
+
+    for token in $(target_prerequisites "$target"); do
+      if printf '%s\n' "$known" | grep -qxF -- "$token"; then
+        queue+=("$token")
+      fi
+    done
+  done
+
+  printf '%s\n' $seen | sort -u
+}
+
+# Every `run: make <target>` a pull-request workflow executes. GitHub expressions such as
+# `${{ matrix.formFactor }}` are collapsed to `*` so a matrix-fanned target is matched as
+# the family it stands for instead of being silently dropped.
+pull_request_workflow_targets() {
+  local workflow
+
+  for workflow in "$PROJECT_ROOT"/.github/workflows/*.yml; do
+    grep -qF 'pull_request:' "$workflow" || continue
+
+    sed -E 's/\$\{\{[^}]*\}\}/*/g' "$workflow" \
+      | sed -n -E 's/^[[:space:]]*run:[[:space:]]*make[[:space:]]+([A-Za-z0-9_.*-]+).*/\1/p'
+  done | sort -u
+}
+
+gate_equivalent() {
+  local key="GATE_EQUIVALENT_${1//[^A-Za-z0-9]/_}"
+
+  printf '%s\n' "${!key:-$1}"
+}
+
+# ---- gate-runner behavior ----------------------------------------------------
+
+@test "make ci runs the fast gate set in order and reports every gate as passing" {
+  run_gate_set ci
+  [ "$status" -eq 0 ]
+
+  run diff -u <(printf '%s\n' lint build test-unit test-integration test-bats) <(executed_gates)
+  [ "$status" -eq 0 ]
+}
+
+@test "make ci prints a gate summary and a passing verdict" {
+  run_gate_set ci
+  [ "$status" -eq 0 ]
+
+  assert_output_contains 'ci gate summary'
+  assert_summary_row lint pass
+  assert_summary_row test-bats pass
+  assert_output_contains 'ci PASSED'
+}
+
+@test "make ci stops at the first failing gate, marks the rest skipped, and exits non-zero" {
+  FAKE_FAILING_GATES=build run_gate_set ci
+  [ "$status" -ne 0 ]
+
+  assert_summary_row lint pass
+  assert_summary_row build FAIL
+  assert_summary_row test-unit skipped
+  assert_summary_row test-integration skipped
+  assert_summary_row test-bats skipped
+  assert_output_contains 'ci FAILED at gate: build'
+
+  assert_log_contains 'gate-make build'
+  assert_log_not_contains 'gate-make test-unit'
+}
+
+@test "make verify runs the ci gate set plus the heavy merge-bar suites" {
+  run_gate_set verify
+  [ "$status" -eq 0 ]
+  assert_output_contains 'verify PASSED'
+
+  run diff -u \
+    <(printf '%s\n' lint build test-unit test-integration test-bats \
+      test-mutation test-e2e test-visual test-memory-leak lighthouse-desktop lighthouse-mobile) \
+    <(executed_gates)
+  [ "$status" -eq 0 ]
+}
+
+@test "make verify fails closed when a heavy gate fails" {
+  FAKE_FAILING_GATES=test-visual run_gate_set verify
+  [ "$status" -ne 0 ]
+
+  assert_summary_row test-visual FAIL
+  assert_summary_row lighthouse-mobile skipped
+  assert_output_contains 'verify FAILED at gate: test-visual'
+}
+
+@test "run-gates refuses to pass vacuously when no gate set is given" {
+  run_gate_set run-gates
+  [ "$status" -ne 0 ]
+  assert_output_contains "run-gates needs a non-empty GATE_SET"
+  assert_log_not_contains 'gate-make'
+}
+
+@test "help advertises the aggregate ci and verify entrypoints" {
+  run_make_target help
+  [ "$status" -eq 0 ]
+  assert_output_contains 'ci'
+  assert_output_contains 'verify'
+}
+
+# ---- gate-set composition ----------------------------------------------------
+
+@test "the verify gate set is a superset of the ci gate set" {
+  local ci_gates verify_gates gate
+  ci_gates="$(makefile_variable CI_GATES)"
+  verify_gates="$(makefile_variable VERIFY_GATES)"
+
+  [ -n "$ci_gates" ]
+
+  for gate in $ci_gates; do
+    printf '%s\n' $verify_gates | grep -qxF -- "$gate"
+  done
+}
+
+@test "every gate in the verify set is a real Makefile target" {
+  local known gate
+  known="$(makefile_target_names)"
+
+  for gate in $(makefile_variable VERIFY_GATES); do
+    printf '%s\n' "$known" | grep -qxF -- "$gate"
+  done
+}
+
+# ---- the merge bar cannot drift away from the workflows ----------------------
+
+@test "the workflow scanner sees the pull-request gates it is meant to police" {
+  local targets
+  targets="$(pull_request_workflow_targets)"
+
+  # A silently empty or truncated scan would make the reachability test below pass
+  # vacuously, so pin a few gates the workflows are known to run.
+  printf '%s\n' "$targets" | grep -qxF -- 'test-unit'
+  printf '%s\n' "$targets" | grep -qxF -- 'test-mutation-shard'
+  printf '%s\n' "$targets" | grep -qxF -- 'lighthouse-*'
+}
+
+@test "every gate a pull request workflow runs is reachable from make verify" {
+  local closure target unreachable=""
+  closure="$(verify_closure)"
+
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+
+    case " ${PLUMBING_TARGETS[*]} " in
+      *" $target "*) continue ;;
+    esac
+
+    target="$(gate_equivalent "$target")"
+
+    if [ "${target%\*}" != "$target" ]; then
+      printf '%s\n' "$closure" | grep -qE "^${target%\*}[A-Za-z0-9_.-]+$" && continue
+    else
+      printf '%s\n' "$closure" | grep -qxF -- "$target" && continue
+    fi
+
+    unreachable="$unreachable $target"
+  done < <(pull_request_workflow_targets)
+
+  if [ -n "$unreachable" ]; then
+    echo "Pull-request gate(s) not reachable from 'make verify':$unreachable" >&2
+    echo "--- verify closure ---" >&2
+    printf '%s\n' "$closure" >&2
+    return 1
+  fi
+}
+
+# ---- documentation -----------------------------------------------------------
+
+@test "README.md and CONTRIBUTING.md document ci and verify as the pre-push commands" {
+  local doc
+  for doc in README.md CONTRIBUTING.md; do
+    grep -qF 'make ci' "$PROJECT_ROOT/$doc"
+    grep -qF 'make verify' "$PROJECT_ROOT/$doc"
+  done
+}
+
+@test "agents.md points contributors at the aggregate gate commands" {
+  grep -qF 'make verify' "$PROJECT_ROOT/agents.md"
+}

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -45,3 +45,6 @@ test-mutation-shard	bats	tests/bats/makefile_targets.bats	Validated for the runn
 copy-mutation-report	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the copy-success branch.
 stage-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated for the missing-container failure and the host-to-container copy branch.
 merge-mutation-reports	bats	tests/bats/makefile_targets.bats	Validated for the running-container and fresh-container branches of the merge gate.
+ci	bats	tests/bats/aggregate_gate_targets.bats	Validated as the fast pre-push aggregate gate set, including fail-fast ordering and the summary table.
+verify	bats	tests/bats/aggregate_gate_targets.bats	Validated as the full merge-bar aggregate, including workflow-gate reachability.
+run-gates	bats	tests/bats/aggregate_gate_targets.bats	Validated as the shared gate runner behind ci and verify, including the empty-GATE_SET guard.


### PR DESCRIPTION
Closes #98.

## What changed

The merge bar now has one canonical definition — the `Makefile` — and one command that proves it.

- **`make ci`** — the fast pre-push set: `lint`, `build`, `test-unit`, `test-integration`, `test-bats`.
- **`make verify`** — everything a merge requires: `make ci` plus `test-mutation`, `test-e2e`, `test-visual`, `test-memory-leak`, `lighthouse-desktop`, `lighthouse-mobile`.

Both delegate to a shared `run-gates` recipe driven by the `CI_GATES` / `VERIFY_GATES` variables. It runs each gate in order, stops at the first failure, exits non-zero, and prints a summary so a partial run can never read as a green one:

```
verify gate summary
  lint                 pass
  build                pass
  test-unit            FAIL
  test-integration     skipped
  ...

verify FAILED at gate: test-unit
```

`run-gates` fails rather than passing vacuously when handed an empty `GATE_SET`.

## Why it can't drift

`tests/bats/aggregate_gate_targets.bats` extracts every `run: make …` line from the pull-request workflows and compares it against the **transitive** dependency graph of `verify` (which is what expands the `lint` aggregate into its eight linters). A workflow gate that `make verify` cannot reach fails the suite. Two documented exemptions:

- **Environment plumbing** (`install`, `start`, `start-bun`, `up`, `down`, `copy-coverage`, `copy-mutation-report`, `stage-mutation-reports`) — these boot, tear down, or move artifacts and assert nothing on their own.
- **Sharded mutation equivalents** — CI fans `test-mutation-shard` across a matrix and re-enforces the same Stryker break threshold in `merge-mutation-reports`; `make verify` runs that identical gate unsharded as `test-mutation`.

The guard is not vacuous: dropping `test-mutation` from `VERIFY_GATES` turns the test red (verified locally).

The runner's own behaviour — ordering, fail-fast, skip marking, summary rows, non-zero exit — is covered by driving `ci`/`verify` with a stubbed `MAKE_GATE`, so the tests never boot the real suites. The three new targets are registered in `tests/bats/make-target-coverage.tsv`.

## Docs

`README.md` leads with the two commands and lists them in the gating table. `CONTRIBUTING.md` gets a "Prove it green before you push" section covering the summary table, where to register a new gate (`CI_GATES` / `VERIFY_GATES`), and why the exemptions exist. `agents.md` points agents at the same commands from its verification step.

## Note on the first commit

`fix(#98): bump the drifted nodejs apk pin` is unrelated to this feature. Alpine dropped `nodejs-22.23.0-r0` from v3.22, so **every** docker-backed job on `main` currently fails at `apk add` before running a check. The same one-line fix is also in #128; whichever lands first, the other drops out cleanly. Verified with `apk add -s` against the pinned base image for both the base and chromium package sets.

## Acceptance criteria

- [x] `make ci` exists, runs lint + build + unit + integration + bats, exits non-zero if any sub-target fails
- [x] `make verify` additionally runs mutation, e2e, visual, memory-leak, and both Lighthouse form factors
- [x] Every gate a PR workflow invokes is reachable from `make verify`, checked by Bats against the `verify` dependency graph
- [x] `tests/bats/target_coverage_contract.bats` passes with the new targets covered
- [x] `README.md` and `CONTRIBUTING.md` document `make ci` / `make verify` as the pre-push commands
- [x] Clone → green is `make install && make verify`

## Verification

`make test-bats` — 282/282 passing in the Docker `bun` service (the 13 new cases included). `bun x markdownlint` and `bun x prettier --check` clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `make ci` and `make verify` as the canonical gate runners so developers can prove branches green locally and keep CI in sync. The workflow reachability guard now covers `.yaml` workflows, list-item and block-scalar `run` steps, wrapped/prefixed `make` calls, and strips comments per command segment to prevent false negatives.

- **New Features**
  - Aggregate targets: `make ci` runs `lint`, `build`, `test-unit`, `test-integration`, `test-bats`; `make verify` adds `test-mutation`, `test-e2e`, `test-visual`, `test-memory-leak`, `lighthouse-desktop`, `lighthouse-mobile`.
  - Shared runner `run-gates` with fail-fast ordering, non-empty `GATE_SET` guard, and a summary table; gate sets in `CI_GATES` and `VERIFY_GATES`.
  - Bats suite `tests/bats/aggregate_gate_targets.bats` enforces every PR workflow `run: make …` is reachable from `verify` (plumbing exempt; sharded mutation maps to `test-mutation`); docs updated in `README.md`, `CONTRIBUTING.md`, and `agents.md`.

- **Bug Fixes**
  - `Dockerfile`: bump `nodejs` to `22.23.2-r0` to fix `apk add` failures in Docker-backed jobs.
  - Reachability scanner widened to include `.yaml` workflows, list-item `- run:`, and block-scalar `run: |` bodies; command-position parsing catches `cd … && make x` and treats wrapped/prefixed invocations (`sudo`, `env`, var assignments, `sh -c`, `time`, `nice`, `command`, `exec`, `xargs`, `then/do/else`) as real; comments are stripped per segment so a quoted `#` cannot hide later invocations; fixtures pin these shapes; docs clarify workflows invoke gate targets directly and tests keep them aligned with `verify`.

<sup>Written for commit cb46e84cca3003d38e19710c347dab147a06f5d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

