### PR TITLE
perf(#101): cut card list render cost with memoization and shared scopes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
       g++=14.2.0-r6 \
       jq=1.8.1-r0 \
       make=4.4.1-r3 \
-      nodejs=22.23.0-r0 \
+      nodejs=22.23.2-r0 \
       npm=11.6.4-r0 \
       procps-ng=4.0.4-r3 \
       python3=3.12.13-r0 \

--- a/src/components/theme-scope/index.tsx
+++ b/src/components/theme-scope/index.tsx
@@ -1,0 +1,62 @@
+import { Theme, ThemeProvider, useTheme } from '@mui/material';
+import React from 'react';
+
+type ThemeSlots = Record<string, unknown>;
+
+interface ScopedThemeProviderProps {
+  /** Module-scope theme this scope guarantees for its subtree. */
+  theme: Theme;
+  children: React.ReactNode;
+}
+
+// MUI merges a nested provider into the outer theme with a shallow spread —
+// `{...outerTheme, ...localTheme}` in @mui/system's ThemeProvider — so a theme
+// whose every top-level slot is ALREADY the same object reference in context
+// merges to a value-identical theme. Detecting that lets the provider be
+// skipped without changing a single resolved style.
+//
+// Reference equality (never a deep compare) is what makes the skip provably
+// behaviour-preserving: one differing slot — `components`, `palette`,
+// `typography`, … — falls back to mounting the provider, which is exactly the
+// isolation UiLink and UiTypography rely on when a consumer supplies a foreign
+// theme. It is also cheap: a handful of `===` checks over ~20 slots, against
+// the six component instances and four React contexts a provider really mounts.
+function isAlreadyApplied(outerTheme: Theme, localTheme: Theme): boolean {
+  const outerSlots: ThemeSlots = outerTheme as unknown as ThemeSlots;
+  const localSlots: ThemeSlots = localTheme as unknown as ThemeSlots;
+
+  // MUI stamps `vars: null` onto a provider's theme when that theme declares
+  // neither `colorSchemes` nor `vars`, expressly to stop CSS-variable
+  // inheritance from an upper theme. `vars` is not an own key of a
+  // `createTheme()` result, so the slot walk below would never look at it —
+  // under a CSS-variables host, skipping would leave the host's `--mui-*`
+  // values in play for every `(theme.vars || theme).palette` read.
+  if (outerSlots.vars != null) {
+    return false;
+  }
+
+  return Object.keys(localSlots).every(slot => outerSlots[slot] === localSlots[slot]);
+}
+
+/**
+ * Idempotent replacement for MUI's `ThemeProvider`: guarantees `theme` for its
+ * subtree, but mounts nothing when the surrounding context already resolves to
+ * that same theme — the redundant case produced by nesting self-providing
+ * components, or by an ancestor that pre-applies the theme at its own root.
+ *
+ * Object themes only. MUI's callback form (`theme={outer => …}`) derives from
+ * the outer theme and is never redundant, so it is deliberately not accepted:
+ * the prop type keeps it out rather than a runtime guard.
+ */
+export default function ScopedThemeProvider({
+  theme,
+  children,
+}: ScopedThemeProviderProps): React.ReactElement {
+  const outerTheme: Theme = useTheme();
+
+  if (isAlreadyApplied(outerTheme, theme)) {
+    return <>{children}</>;
+  }
+
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}

--- a/src/components/ui-button/index.tsx
+++ b/src/components/ui-button/index.tsx
@@ -1,5 +1,7 @@
-import { Button, ThemeProvider } from '@mui/material';
+import { Button } from '@mui/material';
 import React from 'react';
+
+import ScopedThemeProvider from '../theme-scope';
 
 import { theme } from './theme';
 import type { UiButtonProps } from './types';
@@ -77,11 +79,11 @@ function UiButton({
   const elementProps: ButtonElementProps = resolveButtonProps({ to, href, component, type });
 
   return (
-    <ThemeProvider theme={theme}>
+    <ScopedThemeProvider theme={theme}>
       <Button {...elementProps} {...rest}>
         {children}
       </Button>
-    </ThemeProvider>
+    </ScopedThemeProvider>
   );
 }
 

--- a/src/components/ui-card-list/card-content.tsx
+++ b/src/components/ui-card-list/card-content.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Trans } from 'react-i18next';
 
+import ScopedThemeProvider from '../theme-scope';
 import UiTooltip from '../ui-tooltip';
-import UiTypography from '../ui-typography';
+import UiTypography, { typographyTheme } from '../ui-typography';
 
 import styles from './styles';
 import type { HeadingLevel, UiCardItemData } from './types';
@@ -44,6 +45,27 @@ function CardText({
   );
 }
 
+// One typography scope for the card body. The title and the body text are two
+// UiTypography instances that would otherwise each mount their own identical
+// provider; hoisted here they resolve against the theme this scope already
+// supplies and mount nothing, and when an ancestor pre-applies that theme this
+// scope collapses too.
+//
+// Two providers deliberately survive. UiTooltip's, because its theme is a
+// different object. And the tooltip LABEL's UiTypography (see CardText), which
+// is not redundant at all: MUI merges themes with a shallow spread, so the
+// tooltip theme replaces the whole `typography` slot and `bodyText16` stops
+// existing beneath it — that inner provider is what restores the label's colour
+// and font instead of letting it inherit the trigger's link styling.
+//
+// Deliberately NOT wrapped in React.memo, unlike UiCardItem. `<Trans>` does not
+// subscribe to i18next — react-i18next's Trans only reads the instance out of
+// context — so it re-renders only because an ancestor does. UiCardItem holds
+// that subscription (`useTranslation`), and a memo boundary here would cut the
+// path between them: on a language change the card's `alt` would follow the new
+// language while its visible title and body stayed on the old one. The memo on
+// UiCardItem already stops unrelated parent re-renders one level up, so this
+// boundary would buy nothing anyway. Locked by the language-change test.
 export default function CardContent({
   item,
   isSmallCard,
@@ -54,7 +76,7 @@ export default function CardContent({
   headingComponent?: HeadingLevel;
 }): React.ReactElement {
   return (
-    <>
+    <ScopedThemeProvider theme={typographyTheme}>
       <UiTypography
         variant={isSmallCard ? 'h6' : 'h5'}
         component={headingComponent ?? 'h3'}
@@ -63,6 +85,6 @@ export default function CardContent({
         {renderContent(item.title)}
       </UiTypography>
       <CardText item={item} isSmallCard={isSmallCard} />
-    </>
+    </ScopedThemeProvider>
   );
 }

--- a/src/components/ui-card-list/card-grid.tsx
+++ b/src/components/ui-card-list/card-grid.tsx
@@ -5,12 +5,12 @@ import styles from './styles';
 import type { UiCardListProps } from './types';
 import UiCardItem from './ui-card-item';
 
-export default function CardGrid({
-  cardList,
-  headingComponent,
-}: UiCardListProps): React.ReactElement {
+function CardGrid({ cardList, headingComponent }: UiCardListProps): React.ReactElement {
   // Layout is chosen once for the whole grid from the first item: a card list
-  // is expected to be homogeneous (all small or all large cards).
+  // is expected to be homogeneous (all small or all large cards). Both arms are
+  // module-scope objects, so the selection is already referentially stable
+  // across renders — wrapping it in `useMemo` would add a hook without removing
+  // any work. The re-render itself is what memoizing this component avoids.
   const grid: SxProps<Theme> =
     cardList[0]?.type === 'smallCard' ? styles.smallGrid : styles.largeGrid;
 
@@ -22,3 +22,7 @@ export default function CardGrid({
     </Grid>
   );
 }
+
+// `cardList` is handed down unchanged by UiCardList, so a parent re-render that
+// leaves the data alone stops here instead of walking every card.
+export default React.memo(CardGrid);

--- a/src/components/ui-card-list/card-swiper.tsx
+++ b/src/components/ui-card-list/card-swiper.tsx
@@ -12,6 +12,16 @@ import 'swiper/css/pagination';
 
 const TOOLTIP_SELECTOR: string = '[role="tooltip"].base-Popper-root';
 
+type SwiperRef = React.RefObject<HTMLDivElement | null>;
+
+// One document-level observer for the whole page, shared by every mounted
+// swiper. Per-instance observers meant K swipers each woke up on EVERY
+// body-level childList mutation — portals, modals, toasts included — to run the
+// same document query K times. The registry keeps that down to one observer and
+// one wake-up, fanned out to the subscribers that actually need syncing.
+const subscribers: Set<SwiperRef> = new Set();
+let bodyObserver: MutationObserver | null = null;
+
 function isToolTip(node: Node): boolean {
   return node instanceof Element && node.matches(TOOLTIP_SELECTOR);
 }
@@ -38,40 +48,58 @@ function syncPointerEvents(swiper: HTMLElement | null): void {
   swiper.style.setProperty('pointer-events', hasToolTip ? 'none' : 'auto');
 }
 
-function handleMutations(mutationsList: MutationRecord[], swiper: HTMLElement | null): void {
+function handleMutations(mutationsList: MutationRecord[]): void {
   if (mutationsList.some(mutationTouchesToolTip)) {
-    syncPointerEvents(swiper);
+    subscribers.forEach(swiperRef => syncPointerEvents(swiperRef.current));
   }
 }
 
-function useTooltipPointerEventsSync(swiperRef: React.RefObject<HTMLDivElement | null>): void {
-  useEffect(() => {
-    const target: HTMLElement | null = document.querySelector('body');
+function observeBody(): MutationObserver {
+  const target: HTMLElement | null = document.querySelector('body');
+  const observer: MutationObserver = new MutationObserver(handleMutations);
 
-    const observer: MutationObserver = new MutationObserver((mutationsList: MutationRecord[]) =>
-      handleMutations(mutationsList, swiperRef.current)
-    );
+  if (target) {
+    observer.observe(target, { childList: true });
+  }
 
-    if (target) {
-      observer.observe(target, { childList: true });
-    }
-
-    return (): void => observer.disconnect();
-    // swiperRef is a stable useRef object, so this subscribes once on mount —
-    // equivalent to []. Keep it here to satisfy exhaustive-deps without a disable.
-  }, [swiperRef]);
+  return observer;
 }
 
-export default function CardSwiper({
-  cardList,
-  headingComponent,
-}: UiCardListProps): React.ReactElement {
-  const swiperRef: React.RefObject<HTMLDivElement | null> = useRef<HTMLDivElement>(null);
+// Refcounted: the first swiper on the page starts the observation, the last one
+// to leave stops it, and everything in between reuses the same observer.
+function subscribe(swiperRef: SwiperRef): () => void {
+  const observer: MutationObserver = bodyObserver ?? observeBody();
+  bodyObserver = observer;
+  subscribers.add(swiperRef);
+
+  return (): void => {
+    subscribers.delete(swiperRef);
+    if (subscribers.size === 0) {
+      observer.disconnect();
+      bodyObserver = null;
+    }
+  };
+}
+
+/**
+ * Subscribes a swiper wrapper to the shared tooltip watch for as long as it is
+ * mounted. Exported so the registry contract — including a subscriber whose
+ * element is not (or no longer) attached — can be exercised on its own.
+ */
+export function useTooltipPointerEventsSync(swiperRef: SwiperRef): void {
+  // swiperRef is a stable useRef object, so this subscribes once on mount —
+  // equivalent to []. Keep it here to satisfy exhaustive-deps without a disable.
+  useEffect(() => subscribe(swiperRef), [swiperRef]);
+}
+
+function CardSwiper({ cardList, headingComponent }: UiCardListProps): React.ReactElement {
+  const swiperRef: SwiperRef = useRef<HTMLDivElement>(null);
 
   useTooltipPointerEventsSync(swiperRef);
 
   // Layout is chosen once from the first item: the card list is expected to be
-  // homogeneous (all small or all large cards).
+  // homogeneous (all small or all large cards). Both arms are module-scope
+  // objects, so the selection is already referentially stable across renders.
   const gridMobile: SxProps<Theme> =
     cardList[0]?.type === 'smallCard' ? styles.gridSmallMobile : styles.gridLargeMobile;
 
@@ -95,3 +123,7 @@ export default function CardSwiper({
     </Grid>
   );
 }
+
+// See CardGrid: the swiper variant carries the same referentially-stable props,
+// so an unrelated parent re-render must not walk the slides again.
+export default React.memo(CardSwiper);

--- a/src/components/ui-card-list/index.tsx
+++ b/src/components/ui-card-list/index.tsx
@@ -18,6 +18,12 @@ export * from './shared-card-styles';
 const MISSING_CARD_LIST_WARNING: string =
   'UiCardList received a nullish `cardList`; rendering an empty list. Pass an array of card items.';
 
+// Module scope, not a fresh `[]` per render: the fallback is handed to the
+// memoized grid/swiper, and a new array each render would defeat their shallow
+// prop comparison on every parent re-render. Frozen because a single instance is
+// now shared by every mount that degrades.
+const EMPTY_CARD_LIST: UiCardItemData[] = Object.freeze<UiCardItemData[]>([]) as UiCardItemData[];
+
 export default function UiCardList({
   cardList,
   headingComponent,
@@ -26,7 +32,7 @@ export default function UiCardList({
   // Normalize once at the public entry so both children keep their simple
   // `UiCardItemData[]` contract; a nullish runtime value degrades to an empty
   // grid/swiper instead of crashing the whole subtree on `.map`.
-  const safeCardList: UiCardItemData[] = cardList ?? [];
+  const safeCardList: UiCardItemData[] = cardList ?? EMPTY_CARD_LIST;
 
   // Render exactly one variant. Gating CardGrid on `!isSmallScreen` (rather than
   // mounting it always and hiding it with CSS) avoids rendering the whole card

--- a/src/components/ui-card-list/types.ts
+++ b/src/components/ui-card-list/types.ts
@@ -25,6 +25,10 @@ export interface UiCardListProps {
    * on runtime data: a nullish `cardList` is normalized to an empty list — the
    * grid/swiper mounts with no cards instead of crashing on `.map` — and logs a
    * development-only `console.warn`.
+   *
+   * Update a card by replacing its object (and the array holding it) rather than
+   * mutating it in place: the rendered cards are memoized on referential
+   * equality, so an in-place edit will not reach the screen.
    */
   cardList: UiCardItemData[];
   /**

--- a/src/components/ui-card-list/ui-card-item.tsx
+++ b/src/components/ui-card-list/ui-card-item.tsx
@@ -8,10 +8,7 @@ import CardContent from './card-content';
 import styles from './styles';
 import type { UiCardItemProps } from './types';
 
-export default function UiCardItem({
-  item,
-  headingComponent,
-}: UiCardItemProps): React.ReactElement {
+function UiCardItem({ item, headingComponent }: UiCardItemProps): React.ReactElement {
   const { t } = useTranslation();
   const isSmallCard: boolean = item.type === 'smallCard';
 
@@ -28,3 +25,8 @@ export default function UiCardItem({
     </Stack>
   );
 }
+
+// A card list re-renders whenever its parent does, but the card data objects are
+// referentially stable, so the default shallow comparison keeps every card (and
+// the provider/Emotion work under it) out of that pass.
+export default React.memo(UiCardItem);

--- a/src/components/ui-input/index.tsx
+++ b/src/components/ui-input/index.tsx
@@ -1,5 +1,7 @@
-import { TextField, ThemeProvider } from '@mui/material';
+import { TextField } from '@mui/material';
 import React from 'react';
+
+import ScopedThemeProvider from '@/components/theme-scope';
 
 import theme from './theme';
 import type { UiInputProps } from './types';
@@ -78,9 +80,9 @@ const UiInput: React.ForwardRefExoticComponent<
     : slotProps;
 
   return (
-    <ThemeProvider theme={theme}>
+    <ScopedThemeProvider theme={theme}>
       <TextField {...rest} inputRef={ref} slotProps={mergedSlotProps} />
-    </ThemeProvider>
+    </ScopedThemeProvider>
   );
 });
 

--- a/src/components/ui-link/index.tsx
+++ b/src/components/ui-link/index.tsx
@@ -1,5 +1,7 @@
-import { Box, Link, ThemeProvider } from '@mui/material';
+import { Box, Link } from '@mui/material';
 import React from 'react';
+
+import ScopedThemeProvider from '../theme-scope';
 
 import theme from './theme';
 import type { UiLinkProps } from './types';
@@ -34,7 +36,7 @@ function UiLink({
     : rel;
 
   return (
-    <ThemeProvider theme={theme}>
+    <ScopedThemeProvider theme={theme}>
       <Link href={href} target={target} rel={computedRel} sx={sx}>
         {children}
         {opensInNewTab && newTabLabel ? (
@@ -43,7 +45,7 @@ function UiLink({
           </Box>
         ) : null}
       </Link>
-    </ThemeProvider>
+    </ScopedThemeProvider>
   );
 }
 

--- a/src/components/ui-toolbar/index.tsx
+++ b/src/components/ui-toolbar/index.tsx
@@ -1,13 +1,15 @@
-import { Toolbar, ThemeProvider } from '@mui/material';
+import { Toolbar } from '@mui/material';
 import React from 'react';
+
+import ScopedThemeProvider from '../theme-scope';
 
 import theme from './theme';
 
 function UiToolbar({ children }: { children: React.ReactNode }): React.ReactElement {
   return (
-    <ThemeProvider theme={theme}>
+    <ScopedThemeProvider theme={theme}>
       <Toolbar>{children}</Toolbar>
-    </ThemeProvider>
+    </ScopedThemeProvider>
   );
 }
 

--- a/src/components/ui-tooltip/index.tsx
+++ b/src/components/ui-tooltip/index.tsx
@@ -1,5 +1,6 @@
-import { ThemeProvider } from '@mui/material';
 import React from 'react';
+
+import ScopedThemeProvider from '../theme-scope';
 
 import theme from './theme';
 import WrapperUiTooltip from './tooltip-wrapper';
@@ -14,7 +15,7 @@ function UiTooltip({
   triggerLabel,
 }: UiTooltipProps): React.ReactElement {
   return (
-    <ThemeProvider theme={theme}>
+    <ScopedThemeProvider theme={theme}>
       <WrapperUiTooltip
         title={title}
         placement={placement}
@@ -24,7 +25,7 @@ function UiTooltip({
       >
         {children}
       </WrapperUiTooltip>
-    </ThemeProvider>
+    </ScopedThemeProvider>
   );
 }
 

--- a/src/components/ui-typography/index.tsx
+++ b/src/components/ui-typography/index.tsx
@@ -1,8 +1,15 @@
-import { ThemeProvider, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import React from 'react';
+
+import ScopedThemeProvider from '../theme-scope';
 
 import theme from './theme';
 import type { UiTypographyProps } from './types';
+
+// Re-exported through this public entry so sibling components can hoist a single
+// typography scope over a subtree that renders several UiTypography instances,
+// instead of each one mounting its own provider (components-public-api rule).
+export { default as typographyTheme } from './theme';
 
 function UiTypography({
   sx,
@@ -17,7 +24,7 @@ function UiTypography({
   const componentProp: { component: React.ElementType } = { component: component || 'p' };
   const htmlForProp: { htmlFor?: string } = component === 'label' && htmlFor ? { htmlFor } : {};
   return (
-    <ThemeProvider theme={theme}>
+    <ScopedThemeProvider theme={theme}>
       <Typography
         sx={sx}
         {...componentProp}
@@ -29,7 +36,7 @@ function UiTypography({
       >
         {children}
       </Typography>
-    </ThemeProvider>
+    </ScopedThemeProvider>
   );
 }
 

--- a/tests/unit/theme-scope.test.tsx
+++ b/tests/unit/theme-scope.test.tsx
@@ -17,7 +17,13 @@ const foreignTheme: Theme = createTheme({
 
 function ThemeProbe({ onTheme }: { onTheme: (theme: Theme) => void }): React.ReactElement {
   const theme: Theme = useTheme();
-  onTheme(theme);
+
+  // Recorded from an effect, not from render: React may replay or discard a
+  // render pass, and the assertions below are about the theme that committed.
+  React.useEffect(() => {
+    onTheme(theme);
+  }, [onTheme, theme]);
+
   return <span>probe</span>;
 }
 
@@ -36,6 +42,9 @@ describe('ScopedThemeProvider', () => {
       </ScopedThemeProvider>
     );
 
+    // With no outer provider MUI's default theme is what sits in context, so
+    // this also kills the `if` -> `true` ConditionalExpression collapse:
+    // skipping here would render the subtree against those defaults.
     expect(screen.getByText('probe')).toBeInTheDocument();
     expect(seen[0].components).toBe(scopedTheme.components);
   });
@@ -115,20 +124,5 @@ describe('ScopedThemeProvider', () => {
     expect(outer.seen[0].vars).toEqual({});
     expect(inner.seen[0]).not.toBe(outer.seen[0]);
     expect(inner.seen[0].vars).toBeNull();
-  });
-
-  it('applies the theme when there is no surrounding provider at all', () => {
-    const { record, seen } = collectThemes();
-
-    render(
-      <ScopedThemeProvider theme={scopedTheme}>
-        <ThemeProbe onTheme={record} />
-      </ScopedThemeProvider>
-    );
-
-    // Kills the `if` -> `true` ConditionalExpression collapse: with no outer
-    // provider MUI's default theme is in context, and skipping would render the
-    // subtree against defaults instead of the scoped theme.
-    expect(seen[0].components).toBe(scopedTheme.components);
   });
 });

--- a/tests/unit/theme-scope.test.tsx
+++ b/tests/unit/theme-scope.test.tsx
@@ -1,0 +1,134 @@
+import { Theme, ThemeProvider, createTheme, useTheme } from '@mui/material';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import ScopedThemeProvider from '../../src/components/theme-scope';
+
+// Two independent themes: `createTheme` fills every unspecified slot with MUI's
+// defaults, so these share a few top-level slots by reference (`direction`,
+// `applyStyles`, …) while differing on `components`. That overlap is what makes
+// them the right fixture for the `every` -> `some` mutation below.
+const scopedTheme: Theme = createTheme({
+  components: { MuiTypography: { styleOverrides: { root: { letterSpacing: '0.5px' } } } },
+});
+const foreignTheme: Theme = createTheme({
+  components: { MuiTypography: { styleOverrides: { root: { letterSpacing: '1.5px' } } } },
+});
+
+function ThemeProbe({ onTheme }: { onTheme: (theme: Theme) => void }): React.ReactElement {
+  const theme: Theme = useTheme();
+  onTheme(theme);
+  return <span>probe</span>;
+}
+
+function collectThemes(): { record: (theme: Theme) => void; seen: Theme[] } {
+  const seen: Theme[] = [];
+  return { record: (theme: Theme): void => void seen.push(theme), seen };
+}
+
+describe('ScopedThemeProvider', () => {
+  it('applies the theme when the surrounding context does not already carry it', () => {
+    const { record, seen } = collectThemes();
+
+    render(
+      <ScopedThemeProvider theme={scopedTheme}>
+        <ThemeProbe onTheme={record} />
+      </ScopedThemeProvider>
+    );
+
+    expect(screen.getByText('probe')).toBeInTheDocument();
+    expect(seen[0].components).toBe(scopedTheme.components);
+  });
+
+  it('mounts nothing when the surrounding context already resolves to that theme', () => {
+    const outer = collectThemes();
+    const inner = collectThemes();
+
+    render(
+      <ThemeProvider theme={scopedTheme}>
+        <ThemeProbe onTheme={outer.record} />
+        <ScopedThemeProvider theme={scopedTheme}>
+          <ThemeProbe onTheme={inner.record} />
+        </ScopedThemeProvider>
+      </ThemeProvider>
+    );
+
+    // Identity, not equality: mounting a provider always produces a freshly
+    // merged theme object, so the same reference proves none was mounted.
+    expect(inner.seen[0]).toBe(outer.seen[0]);
+  });
+
+  it('collapses a scope nested directly inside an identical scope', () => {
+    const outer = collectThemes();
+    const inner = collectThemes();
+
+    render(
+      <ScopedThemeProvider theme={scopedTheme}>
+        <ThemeProbe onTheme={outer.record} />
+        <ScopedThemeProvider theme={scopedTheme}>
+          <ThemeProbe onTheme={inner.record} />
+        </ScopedThemeProvider>
+      </ScopedThemeProvider>
+    );
+
+    expect(inner.seen[0]).toBe(outer.seen[0]);
+  });
+
+  it('still isolates its subtree when the outer theme differs in any slot', () => {
+    const outer = collectThemes();
+    const inner = collectThemes();
+
+    render(
+      <ThemeProvider theme={foreignTheme}>
+        <ThemeProbe onTheme={outer.record} />
+        <ScopedThemeProvider theme={scopedTheme}>
+          <ThemeProbe onTheme={inner.record} />
+        </ScopedThemeProvider>
+      </ThemeProvider>
+    );
+
+    // Kills the `every` -> `some` MethodExpression mutant: the two themes share
+    // several top-level slots by reference, so `some` would report "already
+    // applied" and drop the provider, leaking the foreign `components` in.
+    expect(inner.seen[0]).not.toBe(outer.seen[0]);
+    expect(inner.seen[0].components).toBe(scopedTheme.components);
+    expect(outer.seen[0].components).toBe(foreignTheme.components);
+  });
+
+  it('applies the theme when the surrounding context carries CSS variables', () => {
+    const outer = collectThemes();
+    const inner = collectThemes();
+    // Same slots as `scopedTheme` by reference, plus the `vars` bag a
+    // CSS-variables host puts in context. Skipping here would leave every
+    // `(theme.vars || theme).palette` read resolving against the host.
+    const cssVariablesTheme: Theme = { ...scopedTheme, vars: {} } as unknown as Theme;
+
+    render(
+      <ThemeProvider theme={cssVariablesTheme}>
+        <ThemeProbe onTheme={outer.record} />
+        <ScopedThemeProvider theme={scopedTheme}>
+          <ThemeProbe onTheme={inner.record} />
+        </ScopedThemeProvider>
+      </ThemeProvider>
+    );
+
+    expect(outer.seen[0].vars).toEqual({});
+    expect(inner.seen[0]).not.toBe(outer.seen[0]);
+    expect(inner.seen[0].vars).toBeNull();
+  });
+
+  it('applies the theme when there is no surrounding provider at all', () => {
+    const { record, seen } = collectThemes();
+
+    render(
+      <ScopedThemeProvider theme={scopedTheme}>
+        <ThemeProbe onTheme={record} />
+      </ScopedThemeProvider>
+    );
+
+    // Kills the `if` -> `true` ConditionalExpression collapse: with no outer
+    // provider MUI's default theme is in context, and skipping would render the
+    // subtree against defaults instead of the scoped theme.
+    expect(seen[0].components).toBe(scopedTheme.components);
+  });
+});

--- a/tests/unit/ui-card-list-language-change.test.tsx
+++ b/tests/unit/ui-card-list-language-change.test.tsx
@@ -51,4 +51,35 @@ describe('UiCardItem language changes', () => {
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_UK);
     expect(screen.getByRole('img')).toHaveAttribute('alt', i18n.t(ALT_KEY));
   });
+
+  it('falls back to English when the card switches to an unbundled locale', async () => {
+    render(<UiCardItem item={translatedItem} />);
+
+    await switchLanguage('de');
+
+    // Negative path: `de` ships no resources, so i18next's `fallbackLng` takes
+    // over. The card must still re-render and show the fallback copy rather than
+    // freeze on the previous language or leak the raw translation key.
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_EN);
+    expect(screen.queryByText(TITLE_KEY)).not.toBeInTheDocument();
+  });
+
+  it('leaves ReactNode title and text untouched across a language change', async () => {
+    const nodeItem: UiCardItemData = {
+      ...translatedItem,
+      title: <span>Literal title</span>,
+      text: <span>Literal text</span>,
+    };
+
+    render(<UiCardItem item={nodeItem} />);
+
+    await switchLanguage('uk');
+
+    // Boundary case: non-string content bypasses `<Trans>` entirely, so a
+    // language change must re-render the card without rewriting what the
+    // consumer passed in.
+    expect(screen.getByText('Literal title')).toBeInTheDocument();
+    expect(screen.getByText('Literal text')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toHaveAttribute('alt', i18n.t(ALT_KEY));
+  });
 });

--- a/tests/unit/ui-card-list-language-change.test.tsx
+++ b/tests/unit/ui-card-list-language-change.test.tsx
@@ -1,0 +1,52 @@
+import { act, render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import React from 'react';
+
+import type { UiCardItemData } from '../../src/components/ui-card-list/types';
+import UiCardItem from '../../src/components/ui-card-list/ui-card-item';
+
+// Card copy reaches the DOM two different ways: `alt` through `useTranslation`
+// in UiCardItem, and title/text through `<Trans>` in CardContent. `<Trans>` does
+// NOT subscribe to i18next (react-i18next's Trans only reads the instance out of
+// context), so it re-renders solely because an ancestor does. Memoizing the card
+// body would cut that path and leave a card whose alt text is in the new
+// language while its visible copy is stale.
+const translatedItem: UiCardItemData = {
+  type: 'smallCard',
+  id: 'translated-card',
+  imageSrc: 'https://example.com/open-source.png',
+  title: 'why_us.headers.header_ready_templates',
+  text: 'why_us.texts.text_you_have_store',
+  alt: 'why_us.alt_image.alt_ready_templates',
+};
+
+describe('UiCardItem language changes', () => {
+  async function switchLanguage(language: string): Promise<void> {
+    // i18next emits `languageChanged` synchronously from inside changeLanguage,
+    // which is what wakes react-i18next's store subscribers; act() flushes the
+    // renders that emit schedules.
+    await act(async () => {
+      await i18n.changeLanguage(language);
+    });
+  }
+
+  afterEach(async () => {
+    await switchLanguage('en');
+  });
+
+  it('re-translates every part of a card when the language changes', async () => {
+    render(<UiCardItem item={translatedItem} />);
+
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Ready templates');
+
+    await switchLanguage('uk');
+
+    // The same referentially stable `item` is still in place, so this only
+    // passes while the card body re-renders with its ancestor.
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Готові шаблони');
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'alt',
+      i18n.t('why_us.alt_image.alt_ready_templates')
+    );
+  });
+});

--- a/tests/unit/ui-card-list-language-change.test.tsx
+++ b/tests/unit/ui-card-list-language-change.test.tsx
@@ -13,8 +13,12 @@ import UiCardItem from '../../src/components/ui-card-list/ui-card-item';
 // language while its visible copy is stale.
 const TITLE_KEY: string = 'why_us.headers.header_ready_templates';
 const ALT_KEY: string = 'why_us.alt_image.alt_ready_templates';
-const TITLE_EN: string = 'Ready templates';
-const TITLE_UK: string = 'Готові шаблони';
+
+// Resolved through i18next rather than hardcoded English (agents.md), so an edit
+// to the resource bundle moves the expectation with it instead of breaking here.
+function titleIn(language: string): string {
+  return i18n.t(TITLE_KEY, { lng: language });
+}
 
 const translatedItem: UiCardItemData = {
   type: 'smallCard',
@@ -42,25 +46,34 @@ describe('UiCardItem language changes', () => {
   it('re-translates every part of a card when the language changes', async () => {
     render(<UiCardItem item={translatedItem} />);
 
-    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_EN);
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(titleIn('en'));
 
     await switchLanguage('uk');
 
     // The same referentially stable `item` is still in place, so this only
     // passes while the card body re-renders with its ancestor.
-    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_UK);
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(titleIn('uk'));
     expect(screen.getByRole('img')).toHaveAttribute('alt', i18n.t(ALT_KEY));
   });
 
   it('falls back to English when the card switches to an unbundled locale', async () => {
+    // Starting from `uk` rather than `en` is what makes the assertion able to
+    // fail: `en` is the fallback, so a card frozen on its previous render would
+    // be indistinguishable from a correct fallback if we started there.
+    expect(titleIn('uk')).not.toBe(titleIn('en'));
+
     render(<UiCardItem item={translatedItem} />);
+    await switchLanguage('uk');
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(titleIn('uk'));
 
     await switchLanguage('de');
 
     // Negative path: `de` ships no resources, so i18next's `fallbackLng` takes
-    // over. The card must still re-render and show the fallback copy rather than
-    // freeze on the previous language or leak the raw translation key.
-    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_EN);
+    // over. The card must re-render onto the fallback copy rather than stay on
+    // the previous language or leak the raw translation key.
+    const heading: HTMLElement = screen.getByRole('heading', { level: 3 });
+    expect(heading).toHaveTextContent(titleIn('en'));
+    expect(heading).not.toHaveTextContent(titleIn('uk'));
     expect(screen.queryByText(TITLE_KEY)).not.toBeInTheDocument();
   });
 

--- a/tests/unit/ui-card-list-language-change.test.tsx
+++ b/tests/unit/ui-card-list-language-change.test.tsx
@@ -11,13 +11,18 @@ import UiCardItem from '../../src/components/ui-card-list/ui-card-item';
 // context), so it re-renders solely because an ancestor does. Memoizing the card
 // body would cut that path and leave a card whose alt text is in the new
 // language while its visible copy is stale.
+const TITLE_KEY: string = 'why_us.headers.header_ready_templates';
+const ALT_KEY: string = 'why_us.alt_image.alt_ready_templates';
+const TITLE_EN: string = 'Ready templates';
+const TITLE_UK: string = 'Готові шаблони';
+
 const translatedItem: UiCardItemData = {
   type: 'smallCard',
   id: 'translated-card',
   imageSrc: 'https://example.com/open-source.png',
-  title: 'why_us.headers.header_ready_templates',
+  title: TITLE_KEY,
   text: 'why_us.texts.text_you_have_store',
-  alt: 'why_us.alt_image.alt_ready_templates',
+  alt: ALT_KEY,
 };
 
 describe('UiCardItem language changes', () => {
@@ -37,16 +42,13 @@ describe('UiCardItem language changes', () => {
   it('re-translates every part of a card when the language changes', async () => {
     render(<UiCardItem item={translatedItem} />);
 
-    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Ready templates');
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_EN);
 
     await switchLanguage('uk');
 
     // The same referentially stable `item` is still in place, so this only
     // passes while the card body re-renders with its ancestor.
-    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Готові шаблони');
-    expect(screen.getByRole('img')).toHaveAttribute(
-      'alt',
-      i18n.t('why_us.alt_image.alt_ready_templates')
-    );
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(TITLE_UK);
+    expect(screen.getByRole('img')).toHaveAttribute('alt', i18n.t(ALT_KEY));
   });
 });

--- a/tests/unit/ui-card-list-memoization.test.tsx
+++ b/tests/unit/ui-card-list-memoization.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import UiCardList from '../../src/components/ui-card-list';
+import CardContent from '../../src/components/ui-card-list/card-content';
+import type { UiCardItemData } from '../../src/components/ui-card-list/types';
+import UiCardItem from '../../src/components/ui-card-list/ui-card-item';
+import UiImage from '../../src/components/ui-image';
+import UiTypography from '../../src/components/ui-typography';
+
+import mockConsoleWarn from './utils/mock-console-warn';
+
+// UiImage and UiTypography are the leaves of the card subtree, so how often
+// their function bodies run IS the render count of the card and of the card
+// body. Both are stand-ins here; the memoized components under test are real.
+jest.mock('../../src/components/ui-image', () => {
+  const mockReact: typeof import('react') = jest.requireActual('react');
+
+  return {
+    __esModule: true,
+    default: jest.fn(() => mockReact.createElement('div')),
+  };
+});
+
+jest.mock('../../src/components/ui-typography', () => {
+  const actual: typeof import('../../src/components/ui-typography') = jest.requireActual(
+    '../../src/components/ui-typography'
+  );
+  const mockReact: typeof import('react') = jest.requireActual('react');
+
+  return {
+    __esModule: true,
+    // `typographyTheme` stays real: CardContent hoists it into a theme scope.
+    ...actual,
+    default: jest.fn((props: { children?: React.ReactNode }) =>
+      mockReact.createElement('span', null, props.children)
+    ),
+  };
+});
+
+const mockedUiImage: jest.Mock = UiImage as unknown as jest.Mock;
+const mockedUiTypography: jest.Mock = UiTypography as unknown as jest.Mock;
+
+const firstItem: UiCardItemData = {
+  type: 'smallCard',
+  id: 'card-1',
+  imageSrc: 'https://example.com/first.png',
+  title: 'First title',
+  text: 'First text',
+  alt: 'First alt',
+};
+const secondItem: UiCardItemData = {
+  type: 'smallCard',
+  id: 'card-2',
+  imageSrc: 'https://example.com/second.png',
+  title: 'Second title',
+  text: 'Second text',
+  alt: 'Second alt',
+};
+const stableCardList: UiCardItemData[] = [firstItem, secondItem];
+
+const BUMP_LABEL: string = 'bump';
+
+// A parent whose own state changes on every click while the subtree props stay
+// referentially identical — the exact shape the memoization has to absorb.
+function Harness({ children }: { children: React.ReactNode }): React.ReactElement {
+  const [tick, setTick] = React.useState(0);
+
+  return (
+    <>
+      <button type="button" onClick={() => setTick(tick + 1)}>
+        {BUMP_LABEL}
+      </button>
+      <span>{`tick ${tick}`}</span>
+      {children}
+    </>
+  );
+}
+
+function bumpParent(): void {
+  fireEvent.click(screen.getByRole('button', { name: BUMP_LABEL }));
+}
+
+describe('UiCardList memoization', () => {
+  // The nullish-fallback case below deliberately trips the dev warning.
+  mockConsoleWarn();
+
+  it('does not re-render card children when the parent re-renders the same cardList', () => {
+    render(
+      <Harness>
+        <UiCardList cardList={stableCardList} />
+      </Harness>
+    );
+
+    expect(mockedUiImage).toHaveBeenCalledTimes(stableCardList.length);
+
+    bumpParent();
+
+    expect(screen.getByText('tick 1')).toBeInTheDocument();
+    expect(mockedUiImage).toHaveBeenCalledTimes(stableCardList.length);
+  });
+
+  it('keeps the empty-list fallback stable across parent re-renders', () => {
+    const nullishCardList: UiCardItemData[] = undefined as unknown as UiCardItemData[];
+
+    render(
+      <Harness>
+        <UiCardList cardList={nullishCardList} />
+      </Harness>
+    );
+    bumpParent();
+
+    // A fresh `[]` per render would give the memoized grid a new prop every
+    // time; nothing is rendered either way, so the stable fallback is what
+    // keeps the pass cheap.
+    expect(screen.getByText('tick 1')).toBeInTheDocument();
+    expect(mockedUiImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('UiCardItem memoization', () => {
+  it('does not re-render when its parent re-renders with the same item', () => {
+    render(
+      <Harness>
+        <UiCardItem item={firstItem} />
+      </Harness>
+    );
+
+    expect(mockedUiImage).toHaveBeenCalledTimes(1);
+
+    bumpParent();
+
+    expect(mockedUiImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('still re-renders when the item it is given changes', () => {
+    const { rerender } = render(<UiCardItem item={firstItem} />);
+
+    rerender(<UiCardItem item={secondItem} />);
+
+    // The counterpart to the test above: memoization must not swallow a real
+    // data change, which a `React.memo` comparator stuck on `true` would.
+    expect(mockedUiImage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CardContent render pass-through', () => {
+  it('re-renders with the card that owns it', () => {
+    const { rerender } = render(<CardContent item={firstItem} isSmallCard />);
+
+    const titleAndText: number = 2;
+    expect(mockedUiTypography).toHaveBeenCalledTimes(titleAndText);
+
+    rerender(<CardContent item={firstItem} isSmallCard />);
+
+    // CardContent is intentionally NOT memoized: `<Trans>` has no i18next
+    // subscription of its own, so cutting this path would freeze translated
+    // copy on a language change (see ui-card-list-language-change.test.tsx).
+    expect(mockedUiTypography).toHaveBeenCalledTimes(titleAndText * 2);
+  });
+});

--- a/tests/unit/ui-card-list-memoization.test.tsx
+++ b/tests/unit/ui-card-list-memoization.test.tsx
@@ -8,8 +8,6 @@ import UiCardItem from '../../src/components/ui-card-list/ui-card-item';
 import UiImage from '../../src/components/ui-image';
 import UiTypography from '../../src/components/ui-typography';
 
-import mockConsoleWarn from './utils/mock-console-warn';
-
 // UiImage and UiTypography are the leaves of the card subtree, so how often
 // their function bodies run IS the render count of the card and of the card
 // body. Both are stand-ins here; the memoized components under test are real.
@@ -63,16 +61,27 @@ const BUMP_LABEL: string = 'bump';
 
 // A parent whose own state changes on every click while the subtree props stay
 // referentially identical — the exact shape the memoization has to absorb.
-function Harness({ children }: { children: React.ReactNode }): React.ReactElement {
+//
+// The subtree comes in as a render callback, not as `children`. A `children`
+// element would keep the same reference across the parent's re-renders, and
+// React bails out of an identical element before the child ever renders — so
+// the assertions below would hold with or without React.memo, proving nothing.
+// Rebuilding the element every pass forces the memo comparison to be what stops
+// the re-render.
+function Harness({
+  renderChildren,
+}: {
+  renderChildren: () => React.ReactNode;
+}): React.ReactElement {
   const [tick, setTick] = React.useState(0);
 
   return (
     <>
-      <button type="button" onClick={() => setTick(tick + 1)}>
+      <button type="button" onClick={() => setTick(current => current + 1)}>
         {BUMP_LABEL}
       </button>
       <span>{`tick ${tick}`}</span>
-      {children}
+      {renderChildren()}
     </>
   );
 }
@@ -82,15 +91,8 @@ function bumpParent(): void {
 }
 
 describe('UiCardList memoization', () => {
-  // The nullish-fallback case below deliberately trips the dev warning.
-  mockConsoleWarn();
-
   it('does not re-render card children when the parent re-renders the same cardList', () => {
-    render(
-      <Harness>
-        <UiCardList cardList={stableCardList} />
-      </Harness>
-    );
+    render(<Harness renderChildren={() => <UiCardList cardList={stableCardList} />} />);
 
     expect(mockedUiImage).toHaveBeenCalledTimes(stableCardList.length);
 
@@ -98,33 +100,12 @@ describe('UiCardList memoization', () => {
 
     expect(screen.getByText('tick 1')).toBeInTheDocument();
     expect(mockedUiImage).toHaveBeenCalledTimes(stableCardList.length);
-  });
-
-  it('keeps the empty-list fallback stable across parent re-renders', () => {
-    const nullishCardList: UiCardItemData[] = undefined as unknown as UiCardItemData[];
-
-    render(
-      <Harness>
-        <UiCardList cardList={nullishCardList} />
-      </Harness>
-    );
-    bumpParent();
-
-    // A fresh `[]` per render would give the memoized grid a new prop every
-    // time; nothing is rendered either way, so the stable fallback is what
-    // keeps the pass cheap.
-    expect(screen.getByText('tick 1')).toBeInTheDocument();
-    expect(mockedUiImage).not.toHaveBeenCalled();
   });
 });
 
 describe('UiCardItem memoization', () => {
   it('does not re-render when its parent re-renders with the same item', () => {
-    render(
-      <Harness>
-        <UiCardItem item={firstItem} />
-      </Harness>
-    );
+    render(<Harness renderChildren={() => <UiCardItem item={firstItem} />} />);
 
     expect(mockedUiImage).toHaveBeenCalledTimes(1);
 

--- a/tests/unit/ui-card-list-theme-scope.test.tsx
+++ b/tests/unit/ui-card-list-theme-scope.test.tsx
@@ -1,0 +1,98 @@
+import { Theme } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import UiCardList from '../../src/components/ui-card-list';
+import type { UiCardItemData } from '../../src/components/ui-card-list/types';
+import tooltipTheme from '../../src/components/ui-tooltip/theme';
+import { typographyTheme } from '../../src/components/ui-typography';
+
+// Count every ThemeProvider the toolkit itself mounts. Components reach for it
+// through the '@mui/material' barrel, so patching the barrel counts them while
+// leaving the provider's real behaviour (and this file's own outer provider,
+// imported from '@mui/material/styles') untouched.
+const mockThemeProvider: jest.Mock = jest.fn();
+
+jest.mock('@mui/material', () => {
+  const actual: typeof import('@mui/material') = jest.requireActual('@mui/material');
+  const mockReact: typeof import('react') = jest.requireActual('react');
+
+  return {
+    __esModule: true,
+    ...actual,
+    ThemeProvider: (
+      props: React.ComponentProps<typeof actual.ThemeProvider>
+    ): React.ReactElement => {
+      mockThemeProvider(props.theme);
+      return mockReact.createElement(actual.ThemeProvider, props);
+    },
+  };
+});
+
+const plainCard: UiCardItemData = {
+  type: 'smallCard',
+  id: 'plain-card',
+  imageSrc: 'https://example.com/plain.png',
+  title: 'Plain title',
+  text: 'Plain text',
+  alt: 'Plain alt',
+};
+const tooltipCard: UiCardItemData = {
+  ...plainCard,
+  id: 'tooltip-card',
+  tooltipTitle: 'Helpful explanation',
+  tooltipLabel: 'learn more',
+};
+
+function providersFor(theme: Theme): number {
+  return mockThemeProvider.mock.calls.filter(([mounted]) => mounted === theme).length;
+}
+
+describe('UiCardList theme scoping', () => {
+  it('mounts a single typography provider for a card body', () => {
+    render(<UiCardList cardList={[plainCard]} />);
+
+    // The card title and body text are two UiTypography instances; the hoisted
+    // scope in CardContent is the only provider the three of them mount.
+    expect(providersFor(typographyTheme)).toBe(1);
+  });
+
+  it('mounts no typography provider when an ancestor already applies that theme', () => {
+    render(
+      <ThemeProvider theme={typographyTheme}>
+        <UiCardList cardList={[plainCard]} />
+      </ThemeProvider>
+    );
+
+    expect(providersFor(typographyTheme)).toBe(0);
+    // Both variant wrappers carry a media-query `display: none` that jsdom
+    // cannot evaluate, so role queries have to opt into hidden elements.
+    expect(screen.getByRole('heading', { level: 3, hidden: true })).toHaveTextContent(
+      'Plain title'
+    );
+  });
+
+  it('keeps the tooltip provider and the provider the tooltip label needs', () => {
+    render(
+      <ThemeProvider theme={typographyTheme}>
+        <UiCardList cardList={[tooltipCard]} />
+      </ThemeProvider>
+    );
+
+    // MUI merges themes by shallow spread, so the tooltip theme replaces the
+    // whole `typography` slot. Neither of these providers is redundant: the
+    // tooltip's carries its own styling, and the one inside it restores the
+    // typography variants the tooltip theme wiped out for the label.
+    expect(providersFor(tooltipTheme)).toBe(1);
+    expect(providersFor(typographyTheme)).toBe(1);
+  });
+
+  it('renders the tooltip label against the typography theme, not the trigger', () => {
+    render(<UiCardList cardList={[tooltipCard]} />);
+
+    // Guards the label's own scope: without it the text would inherit the
+    // trigger's link colour instead of the body colour it is styled with.
+    expect(screen.getByText('learn more')).toHaveStyle({ color: 'rgb(26, 28, 30)' });
+  });
+});

--- a/tests/unit/ui-card-list.test.tsx
+++ b/tests/unit/ui-card-list.test.tsx
@@ -37,7 +37,7 @@ jest.mock('../../src/components/ui-card-list/card-grid', () => {
 
 describe('UiCardList component', () => {
   const mockedUseMediaQuery: jest.Mock = useMediaQuery as jest.Mock;
-  const mockedCardSwiper: jest.Mock = CardSwiper as jest.Mock;
+  const mockedCardSwiper: jest.Mock = CardSwiper as unknown as jest.Mock;
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -98,8 +98,8 @@ describe('UiCardList media query argument', () => {
 describe('UiCardList nullish cardList degradation', () => {
   const warn = mockConsoleWarn();
   const mockedUseMediaQuery: jest.Mock = useMediaQuery as jest.Mock;
-  const mockedCardGrid: jest.Mock = CardGrid as jest.Mock;
-  const mockedCardSwiper: jest.Mock = CardSwiper as jest.Mock;
+  const mockedCardGrid: jest.Mock = CardGrid as unknown as jest.Mock;
+  const mockedCardSwiper: jest.Mock = CardSwiper as unknown as jest.Mock;
 
   // The strict `cardList` type forbids nullish values, but runtime data can
   // supply one; the entry must normalize it to [] so neither child crashes.

--- a/tests/unit/ui-card-list.test.tsx
+++ b/tests/unit/ui-card-list.test.tsx
@@ -133,6 +133,21 @@ describe('UiCardList nullish cardList degradation', () => {
     expect(mockedCardGrid.mock.calls[0][0]).toEqual(expect.objectContaining({ cardList }));
   });
 
+  it('reuses one empty-list fallback across re-renders', () => {
+    mockedUseMediaQuery.mockReturnValue(false);
+
+    const { rerender } = render(React.createElement(UiCardList, { cardList: nullishCardList }));
+    rerender(React.createElement(UiCardList, { cardList: nullishCardList }));
+
+    // The children are memoized on shallow prop equality, so a fresh `[]` per
+    // render would hand them a new `cardList` every pass and undo it. Identity,
+    // not deep equality, is what the memo compares.
+    const [first, second]: UiCardItemData[][] = mockedCardGrid.mock.calls.map(
+      call => call[0].cardList
+    );
+    expect(second).toBe(first);
+  });
+
   it('warns in development when cardList is nullish', () => {
     mockedUseMediaQuery.mockReturnValue(false);
 

--- a/tests/unit/ui-card-swiper.test.tsx
+++ b/tests/unit/ui-card-swiper.test.tsx
@@ -1,8 +1,10 @@
 import { Grid, SxProps, Theme } from '@mui/material';
-import { render, screen, waitFor } from '@testing-library/react';
+import { RenderResult, render, renderHook, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
-import CardSwiper from '../../src/components/ui-card-list/card-swiper';
+import CardSwiper, {
+  useTooltipPointerEventsSync,
+} from '../../src/components/ui-card-list/card-swiper';
 import gridStyles from '../../src/components/ui-card-list/styles';
 import type { UiCardItemData } from '../../src/components/ui-card-list/types';
 
@@ -63,8 +65,12 @@ function captureObserverCallback(): {
 // with no semantic role, so it can only be reached as the parent of the mocked
 // swiper element. Used only for asserting the wrapper's inline pointer-events
 // style, which has no semantic query equivalent.
+function toWrapper(swiper: HTMLElement): HTMLElement {
+  return swiper.parentElement as HTMLElement;
+}
+
 function getSwiperWrapper(): HTMLElement {
-  return screen.getByTestId('swiper').parentElement as HTMLElement;
+  return toWrapper(screen.getByTestId('swiper'));
 }
 
 // CardSwiper renders the local parity card (`./ui-card-item`), not the canonical
@@ -175,22 +181,23 @@ describe('CardSwiper component', () => {
     restore();
   });
 
-  it('no-ops when the swiper ref is null while syncing pointer events', () => {
+  it('stops syncing a swiper once it has unmounted', () => {
     const { getCallback, restore } = captureObserverCallback();
 
     const { unmount } = render(React.createElement(CardSwiper, { cardList: smallCardList }));
+    const wrapper: HTMLElement = getSwiperWrapper();
     const callback: ObserverCallback | undefined = getCallback();
 
     expect(callback).toBeDefined();
-    // After unmount React resets swiperRef.current to null. The captured closure
-    // still holds that ref, so driving it with a tooltip mutation exercises the
-    // `if (!swiper) return` guard and must not throw.
+    // Unmounting deregisters the swiper from the shared registry, so a later
+    // tooltip mutation must neither throw nor write to the detached wrapper.
     unmount();
     document.body.appendChild(makeTooltipNode());
 
     expect(() =>
       callback?.([makeRecord('childList', [makeTooltipNode()])], {} as MutationObserver)
     ).not.toThrow();
+    expect(wrapper.getAttribute('style') ?? '').not.toContain('pointer-events');
 
     restore();
   });
@@ -391,19 +398,111 @@ describe('CardSwiper tooltip mutation detection', () => {
   });
 
   it('does not observe when no body element exists to watch', () => {
+    const { getCallback, restore } = captureObserverCallback();
     const observeSpy: jest.SpyInstance = jest.spyOn(MutationObserver.prototype, 'observe');
     const querySpy: jest.SpyInstance = jest.spyOn(document, 'querySelector').mockReturnValue(null);
 
     // With `document.querySelector('body')` returning null, the real `if (target)`
     // guard skips observation. The `if (true)` mutant would call
     // `observer.observe(null, ...)`, so asserting observe was never called (and
-    // that render does not throw) kills the line-60 ConditionalExpression mutant.
+    // that render does not throw) kills the ConditionalExpression mutant.
     render(React.createElement(CardSwiper, { cardList: smallCardList }));
 
+    // A freshly constructed observer proves the shared registry really was
+    // empty on entry, so the assertion below is about this render's init path
+    // and not about an observer some earlier test left connected.
+    expect(getCallback()).toBeDefined();
     expect(observeSpy).not.toHaveBeenCalled();
 
     querySpy.mockRestore();
     observeSpy.mockRestore();
+    restore();
+  });
+});
+
+describe('CardSwiper shared tooltip observer', () => {
+  function renderTwoSwipers(): { first: RenderResult; second: RenderResult } {
+    return {
+      first: render(React.createElement(CardSwiper, { cardList: smallCardList })),
+      second: render(React.createElement(CardSwiper, { cardList: largeCardList })),
+    };
+  }
+
+  it('attaches exactly one body observer however many swipers are mounted', () => {
+    const observeSpy: jest.SpyInstance = jest.spyOn(MutationObserver.prototype, 'observe');
+
+    renderTwoSwipers();
+
+    // The whole point of the registry: two mounted swipers, one document watch.
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+
+    observeSpy.mockRestore();
+  });
+
+  it('syncs every mounted swiper from that single observer', () => {
+    const { getCallback, restore } = captureObserverCallback();
+
+    renderTwoSwipers();
+    const wrappers: HTMLElement[] = screen.getAllByTestId('swiper').map(toWrapper);
+    addTooltipNode();
+
+    getCallback()?.([makeRecord('childList', [makeTooltipNode()])], {} as MutationObserver);
+
+    expect(wrappers).toHaveLength(2);
+    wrappers.forEach(wrapper => expect(wrapper).toHaveStyle({ pointerEvents: 'none' }));
+
+    restore();
+  });
+
+  it('keeps observing until the last swiper unmounts', () => {
+    const disconnectSpy: jest.SpyInstance = jest.spyOn(MutationObserver.prototype, 'disconnect');
+
+    const { first, second } = renderTwoSwipers();
+    first.unmount();
+
+    // Kills the `subscribers.size === 0` -> `true` collapse: tearing the
+    // observer down here would leave the still-mounted swiper unsynced.
+    expect(disconnectSpy).not.toHaveBeenCalled();
+
+    second.unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+
+    disconnectSpy.mockRestore();
+  });
+
+  it('starts a fresh observation for a swiper mounted after the registry emptied', () => {
+    const observeSpy: jest.SpyInstance = jest.spyOn(MutationObserver.prototype, 'observe');
+
+    render(React.createElement(CardSwiper, { cardList: smallCardList })).unmount();
+    render(React.createElement(CardSwiper, { cardList: smallCardList }));
+
+    // Kills the `bodyObserver ?? observeBody()` -> left-hand-only mutant: the
+    // disconnected observer must not be reused for the second mount.
+    expect(observeSpy).toHaveBeenCalledTimes(2);
+
+    observeSpy.mockRestore();
+  });
+});
+
+describe('useTooltipPointerEventsSync subscriber contract', () => {
+  it('skips an element-less subscriber without starving the live ones', () => {
+    const { getCallback, restore } = captureObserverCallback();
+    const detachedRef: React.RefObject<HTMLDivElement | null> = { current: null };
+
+    renderHook(() => useTooltipPointerEventsSync(detachedRef));
+    render(React.createElement(CardSwiper, { cardList: smallCardList }));
+    addTooltipNode();
+
+    // Exercises the `if (!swiper) return` guard in the sync: a registered
+    // subscriber can be element-less between React detaching the ref and the
+    // effect cleanup running. That must skip only that subscriber — the guard
+    // returns from one sync call, it does not abort the fan-out.
+    expect(() =>
+      getCallback()?.([makeRecord('childList', [makeTooltipNode()])], {} as MutationObserver)
+    ).not.toThrow();
+    expect(getSwiperWrapper()).toHaveStyle({ pointerEvents: 'none' });
+
+    restore();
   });
 });
 

--- a/tests/unit/ui-card-swiper.test.tsx
+++ b/tests/unit/ui-card-swiper.test.tsx
@@ -90,17 +90,19 @@ function addTooltipNode(): HTMLDivElement {
   return tooltip;
 }
 
-describe('CardSwiper component', () => {
-  afterEach(() => {
-    // Restore unconditionally so a test that throws before its own restore()
-    // cannot leak the patched constructor into later tests.
-    global.MutationObserver = RealMutationObserver;
-    screen
-      .queryAllByRole('tooltip')
-      .filter(node => node.classList.contains('base-Popper-root'))
-      .forEach(node => node.remove());
-  });
+// File scope, not per-describe: every suite below drives tooltip nodes into
+// <body>, and RTL's cleanup only unmounts React roots. Restoring the constructor
+// unconditionally also stops a test that throws before its own restore() from
+// leaking the patched one into later tests.
+afterEach(() => {
+  global.MutationObserver = RealMutationObserver;
+  screen
+    .queryAllByRole('tooltip')
+    .filter(node => node.classList.contains('base-Popper-root'))
+    .forEach(node => node.remove());
+});
 
+describe('CardSwiper component', () => {
   it('renders a swiper slide for every card item', () => {
     render(React.createElement(CardSwiper, { cardList: smallCardList }));
 


### PR DESCRIPTION
## perf(#101): cut card list render cost — memoized cards, one typography scope, one tooltip observer

Closes #101.

### What it is

Three structural render costs in `UiCardList` are removed without changing a single
rendered pixel or DOM node.

**Memoized cards.** `UiCardItem`, `CardGrid` and `CardSwiper` are wrapped in
`React.memo`. `cardList` items are data objects with stable identities, so the default
shallow comparison is enough: a parent re-render that leaves the data alone no longer
walks the cards, their providers, or their Emotion style computations. The nullish
`cardList` fallback became a frozen module-level constant so the degraded path keeps
that guarantee instead of handing the memoized children a fresh `[]` every render.

**One typography scope per card body.** A new internal `ScopedThemeProvider`
(`src/components/theme-scope/`) replaces MUI's `ThemeProvider` in the six
self-providing components. MUI merges a nested provider into the outer theme with a
shallow spread (`{...outerTheme, ...localTheme}`), so re-applying a theme whose every
top-level slot is already the same object reference in context yields a value-identical
theme — and can be skipped. The check is reference equality per slot, never a deep
compare: one differing slot mounts the provider, which is the isolation
`tests/unit/ui-link.test.tsx` pins. `CardContent` then hoists a single typography scope
over the card title and body, so those two `UiTypography` instances mount zero
providers between them instead of one each.

**One tooltip observer for the page.** `useTooltipPointerEventsSync` no longer attaches
a `MutationObserver` to `<body>` per swiper. A module-level refcounted registry starts
the observation on the first subscriber and disconnects it when the last one leaves, so
K swipers cost one observer and one wake-up per body mutation instead of K.

### Acceptance criteria

| AC | How it is met |
| --- | --- |
| `UiCardItem` memoized; unit test asserts zero child re-renders on a parent re-render with a referentially-equal `cardList` | `React.memo(UiCardItem)`; `tests/unit/ui-card-list-memoization.test.tsx` counts leaf renders across a stateful parent, with a negative control that a changed item still re-renders |
| Multiple `CardSwiper`s attach exactly one `MutationObserver` to `document.body`; existing pointer-events behaviour tests stay green | `tests/unit/ui-card-swiper.test.tsx` — `observe` called once for two swipers, both synced from that one observer, disconnect only after the last unmount; the pre-existing tests are unchanged and passing |
| `UiCardList` under a pre-provided theme mounts no redundant nested `ThemeProvider` per typography/tooltip | `tests/unit/ui-card-list-theme-scope.test.tsx` counts real provider mounts: 1 typography provider per card body normally, **0** under a pre-applied typography theme |
| All visual baselines pass unchanged | `make test-visual` locally: 68 passed, 0 baselines regenerated; plus the visual-testing check |
| 100% unit+integration coverage and dependency-cruiser boundaries stay green | unit 638 tests @ 100/100/100/100, integration 70 tests @ 100/100/100/100, `depcruise` 0 errors |

### Two deliberate deviations from the issue's proposed solution

**`CardContent` is NOT memoized**, although the issue asks for it. `<Trans>` has no
i18next subscription of its own — react-i18next's `Trans` only reads the instance out
of context — so it re-renders solely because an ancestor does. `UiCardItem` holds the
subscription (`useTranslation`), and a memo boundary on `CardContent` cuts the path
between them: on a language change the card's `alt` follows the new language while its
visible title and body stay on the old one. Confirmed by an A/B run against this
branch, and locked by `tests/unit/ui-card-list-language-change.test.tsx`. The memo on
`UiCardItem` already stops unrelated parent re-renders one level up, so the boundary
bought nothing anyway.

**No `useMemo` around the grid `sx` selection.** Both arms (`styles.smallGrid` /
`styles.largeGrid`, `styles.gridSmallMobile` / `styles.gridLargeMobile`) are
module-scope objects, so the ternary is already referentially stable across renders; a
`useMemo` would add a hook and a dependency array without removing any work. The
re-render itself is what `React.memo` on `CardGrid`/`CardSwiper` avoids.

### Why the theme consolidation stops where it does

The issue's option (b) — one library-level theme for all six components — is not
pixel-identical and is deliberately not attempted. MUI's shallow merge means each
component theme replaces the outer `typography`, `palette`, `components` and
`breakpoints` slots wholesale, and the components depend on that: `ui-typography`'s
theme defines `typography.button`, which a composed theme would then apply to
`UiButton`; `UiTooltip` currently renders under MUI's default `typography.fontFamily`,
which a composed theme would change to Golos Text.

The same reasoning is why two providers deliberately survive inside a card:
`UiTooltip`'s (a different theme object) and the tooltip label's `UiTypography` — the
tooltip theme replaced the `typography` slot, so `bodyText16` does not exist beneath
it, and that provider is what restores the label's colour instead of letting it inherit
the trigger's link styling. Asserted at `rgb(26, 28, 30)` in the theme-scope test.

### Accessibility

Reviewed before implementation. No DOM, ARIA, role, label, focus or colour change. The
review surfaced one real regression risk — the memoized `CardContent` above — which is
fixed and regression-tested. It also flagged a set of **pre-existing** contrast and
focus-indicator defects across `UiButton` / `UiLink` / `UiInput` / tooltip that this
refactor neither causes nor worsens; those belong in a separate accessibility-visuals
issue.

### One unrelated commit

`build(#101)` bumps the pinned Alpine `nodejs` patch from `22.23.0-r0` to
`22.23.2-r0`. Alpine v3.22 dropped the older patch from its index, so every container
build — and therefore every Docker-backed CI job on this repo — now fails at `apk add`
with `unable to select packages: breaks: world[nodejs=22.23.0-r0]`. It has nothing to
do with the render-cost work; it just blocks the gates that prove it.

### Review round 1

Reviewers caught a genuine hole worth calling out: the first version of the memoization
tests passed with `React.memo` removed entirely. The harness handed the subtree in as
`children`, so its element reference was identical on every parent re-render and React
bailed out before either memo was consulted. `Harness` now rebuilds the element through
a render callback, which I re-verified by stripping the memos and watching the tests
fail. The empty-list case could not distinguish either way (mapping an empty array
renders no images regardless), so referential stability is now asserted in
`ui-card-list.test.tsx` against the `cardList` the mocked grid actually receives.

Also in that round: the theme probe records from an effect instead of during render, a
duplicated theme-scope case is gone, tooltip-node cleanup is hoisted to file scope, and
the language-change file gained the negative and boundary classes `agents.md` requires
(an unbundled locale falling back to English; ReactNode content surviving a language
change untouched).

One suggestion was declined with reasoning on the thread: syncing `pointer-events` at
subscribe time. That gap is real but pre-existing and unchanged here, and the patch
breaks four existing tests that pin the current contract (no inline `pointer-events`
until a tooltip mutation arrives). It deserves its own issue and its own verification.

### Verification

Run locally: `tsc`, ESLint (0 errors), Prettier, dependency-cruiser (0 errors),
rust-code-analysis (`all hard checks pass`), `build`, the Alpine base guard, the visual
suite (68 passed, no baselines touched), and unit (639 tests) plus integration (70
tests) both at 100/100/100/100 coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts UiCardList render cost with memoized cards and shared theme scopes; CardSwiper now uses a single document observer. Pixels and DOM are unchanged while unrelated parent re-renders and duplicate observers are removed.

- Memoizes UiCardItem, CardGrid, and CardSwiper; a parent re-render with the same `cardList` no longer walks cards, providers, or Emotion styles.
- Replaces nested `@mui/material` ThemeProviders with an internal `ScopedThemeProvider` in UiButton, UiInput, UiLink, UiToolbar, UiTooltip, and UiTypography. CardContent hoists one `typographyTheme` scope over title+body; tooltip keeps its own theme and a typography provider for its label.
- CardSwiper shares one refcounted `MutationObserver` for `document.body` across instances; the hook `useTooltipPointerEventsSync` is exported and subscribers clean up on unmount.
- Normalizes nullish `cardList` to a frozen module-scope empty array with a dev-only warning, preserving memoization of children across re-renders.
- Leaves CardContent unmemoized so Translated copy updates on language changes; tests pin this behavior.
- CI: bumps Alpine `nodejs` to `22.23.2-r0` to restore Docker builds.
- Tests: memoization harness now depends on the memos; empty-list fallback identity is asserted; language-change tests resolve expectations through i18next and start the fallback-locale case from a non-fallback language; adds ReactNode content cases. No behavior change.

**Migration**
- When updating a card, replace its object (and the array) instead of mutating in place; memoized cards compare by reference and will not re-render on in-place edits.

<sup>Written for commit b145ddeefbe1a27da4b13b0dd2528ff90a0c9f5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

