### PR TITLE
test(#100): Storybook interaction (play function) tests and the test-storybook gate

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -46,7 +46,7 @@ module.exports = {
           '\\.d\\.ts$', // type declarations (Types.d.ts, styles.d.ts, react-app-env.d.ts)
           '(^|/)tsconfig\\.json$',
           '(^|/)(?:babel|webpack)\\.config\\.(?:js|cjs|mjs|ts|json)$',
-          '[.]stories[.](?:tsx?|jsx?)$', // Storybook stories are entry points, not orphans
+          '[.]stories[.](?:mjs|tsx?|jsx?)$', // Storybook stories are entry points, not orphans
           'fonts\\.css$', // side-effect import in src/components/index.ts
           '^src/(components/)?index\\.(ts|tsx)$', // public entry barrels
         ],
@@ -118,7 +118,7 @@ module.exports = {
         'This module uses a peerDependency directly. For a published component ' +
         'library this is expected (the consumer supplies it); kept visible as ' +
         'an advisory warn.',
-      from: { pathNot: '[.](?:spec|test|stories)[.](?:tsx?|jsx?)$' },
+      from: { pathNot: '[.](?:spec|test|stories)[.](?:mjs|tsx?|jsx?)$' },
       to: { dependencyTypes: ['npm-peer'] },
     },
     // ---- Dev-only dependency leak (re-scoped for a dev+peer library) ----
@@ -131,7 +131,7 @@ module.exports = {
         'library mirrors into both devDependencies and peerDependencies are ' +
         'spared via dependencyTypesNot: [npm-peer] (combinedDependencies tags ' +
         'them as both npm-dev and npm-peer), so only true dev-only modules fail.',
-      from: { path: '^src', pathNot: '[.](?:spec|test|stories)[.](?:tsx?|jsx?)$' },
+      from: { path: '^src', pathNot: '[.](?:spec|test|stories)[.](?:mjs|tsx?|jsx?)$' },
       to: {
         dependencyTypes: ['npm-dev'],
         dependencyTypesNot: ['npm-peer', 'type-only'],
@@ -161,7 +161,7 @@ module.exports = {
       comment:
         'Production src/ code must not import a *.stories.* file. Stories are ' +
         'Storybook entry points, not shippable modules.',
-      from: { path: '^src', pathNot: '[.]stories[.](?:tsx?|jsx?)$' },
+      from: { path: '^src', pathNot: '[.]stories[.](?:mjs|tsx?|jsx?)$' },
       to: { path: '\\.stories\\.' },
     },
     {

--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -46,7 +46,7 @@ module.exports = {
           '\\.d\\.ts$', // type declarations (Types.d.ts, styles.d.ts, react-app-env.d.ts)
           '(^|/)tsconfig\\.json$',
           '(^|/)(?:babel|webpack)\\.config\\.(?:js|cjs|mjs|ts|json)$',
-          '\\.stories\\.tsx$', // Storybook stories are entry points, not orphans
+          '[.]stories[.](?:tsx?|jsx?)$', // Storybook stories are entry points, not orphans
           'fonts\\.css$', // side-effect import in src/components/index.ts
           '^src/(components/)?index\\.(ts|tsx)$', // public entry barrels
         ],
@@ -161,7 +161,7 @@ module.exports = {
       comment:
         'Production src/ code must not import a *.stories.* file. Stories are ' +
         'Storybook entry points, not shippable modules.',
-      from: { path: '^src', pathNot: '\\.stories\\.tsx$' },
+      from: { path: '^src', pathNot: '[.]stories[.](?:tsx?|jsx?)$' },
       to: { path: '\\.stories\\.' },
     },
     {

--- a/.github/workflows/storybook-interaction-testing.yml
+++ b/.github/workflows/storybook-interaction-testing.yml
@@ -1,0 +1,39 @@
+name: Storybook interaction tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  storybook-interaction-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CI: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      # No "detect inputs / skip" guard on purpose (issue #100): a conditional skip
+      # path would let the interaction suite disappear silently. The gate itself is
+      # fail-closed — scripts/ci/run-storybook-interactions.ts exits non-zero when
+      # the live Storybook index and tests/storybook/interaction-stories.json
+      # disagree, when fewer than the required components carry play functions, or
+      # when any registered play test does not run and pass.
+      - name: Install dependencies
+        run: make install
+
+      - name: Run Storybook interaction tests
+        run: make test-storybook

--- a/.storybook/field-typeahead-interactions.ts
+++ b/.storybook/field-typeahead-interactions.ts
@@ -1,0 +1,47 @@
+import { expect, screen, userEvent, within } from 'storybook/test';
+
+// Shared `play` body for the typeahead field controls (UiSearchInput,
+// UiSelectWithSearch). Both prove the same contract — typing narrows the listbox
+// and clicking a surviving option writes it into the field — so the interaction
+// lives here once instead of being duplicated per story module.
+// See tests/storybook/README.md.
+
+/** What a typeahead narrow-and-select interaction needs to drive one field. */
+export interface TypeaheadSelection {
+  /** The story's canvas root, from the `play` context. */
+  canvasElement: HTMLElement;
+  /** Accessible name of the combobox under test. */
+  fieldName: string;
+  /** Text typed into the field to narrow the listbox. */
+  query: string;
+  /** Option that must survive `query` and become the field's value. */
+  chosenOption: string;
+  /** Option that `query` must filter out of the listbox. */
+  filteredOutOption: string;
+}
+
+/**
+ * Types `query` into the named combobox, asserts `filteredOutOption` is gone from
+ * the listbox, clicks `chosenOption` and asserts it became the field's value.
+ *
+ * The listbox is portalled outside the story canvas, so options are queried from
+ * `screen` while the field itself is queried from within the canvas.
+ */
+export async function expectTypeaheadNarrowsAndSelects({
+  canvasElement,
+  fieldName,
+  query,
+  chosenOption,
+  filteredOutOption,
+}: TypeaheadSelection): Promise<void> {
+  const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: fieldName });
+
+  await userEvent.type(field, query);
+  const match: HTMLElement = await screen.findByRole('option', { name: chosenOption });
+
+  await expect(screen.queryByRole('option', { name: filteredOutOption })).toBeNull();
+
+  await userEvent.click(match);
+
+  await expect(field).toHaveValue(chosenOption);
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ own subdirectory:
 - `tests/integration` — Jest composition tests across components
 - `tests/e2e` — Playwright end-to-end specs run against Storybook
 - `tests/visual` — Playwright visual-regression specs and their snapshots
+- `tests/storybook` — the Storybook interaction (play function) registry and its docs
 - `tests/load` — k6 load tests
 - `tests/memory-leak` — Memlab leak scenarios
 - `tests/bats` — Bats coverage for Makefile and CI shell flows

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN apk add --no-cache \
       g++=14.2.0-r6 \
       jq=1.8.1-r0 \
       make=4.4.1-r3 \
-      nodejs=22.23.0-r0 \
+      nodejs=22.23.2-r0 \
       npm=11.6.4-r0 \
       procps-ng=4.0.4-r3 \
-      python3=3.12.13-r0 \
+      python3=3.12.14-r0 \
     && if [ "$INSTALL_CHROMIUM" = "true" ]; then \
          apk add --no-cache \
            chromium=142.0.7444.59-r0 \

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -34,8 +34,8 @@ COPY src ./src
 COPY tests ./tests
 
 RUN bun install --frozen-lockfile \
-    && mkdir -p /home/pwuser/.bun-cache \
-    && chown -R pwuser:pwuser /home/pwuser/.bun-cache \
+    && mkdir -p /home/pwuser/.bun-cache /app/node_modules/.cache \
+    && chown -R pwuser:pwuser /home/pwuser/.bun-cache /app/node_modules/.cache \
     && chown pwuser:pwuser /app
 
 USER pwuser

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,16 @@ MUTATION_REPORTS_DIR = reports/mutation
 .PHONY: help build lint lint-next lint-tsc lint-md format-check lint-test-structure git-hooks-install \
 	storybook-start storybook-build generate-ts-doc test-e2e test-e2e-local \
 	test-unit test-integration copy-coverage test-mutation test-memory-leak test-visual \
+	test-storybook \
 	lighthouse-desktop lighthouse-mobile install update playwright-install test-bats \
 	up down sh ps logs new-logs start start-bun stop build-k6-docker load-tests run-storybook-playwright \
 	lint-dep-ranges lint-deps lint-metrics lint-metrics-run \
 	test-mutation-shard copy-mutation-report stage-mutation-reports merge-mutation-reports
 
 PLAYWRIGHT_TEST_ARGS =
+# Command the shared helper runs against the booted Storybook. Playwright specs are
+# the default; `test-storybook` swaps in the Storybook interaction-suite gate.
+PLAYWRIGHT_RUN_CMD ?= bun x playwright test
 
 run-storybook-playwright:
 	@test -n "$(PLAYWRIGHT_TEST_TARGET)"
@@ -52,7 +56,7 @@ run-storybook-playwright:
 			$(DOCKER_COMPOSE) logs storybook; \
 			exit 1; \
 		fi; \
-		$(DOCKER_COMPOSE) run --rm playwright bun x playwright test $(PLAYWRIGHT_TEST_TARGET) $(PLAYWRIGHT_TEST_ARGS)
+		$(DOCKER_COMPOSE) run --rm playwright $(PLAYWRIGHT_RUN_CMD) $(PLAYWRIGHT_TEST_TARGET) $(PLAYWRIGHT_TEST_ARGS)
 
 help:
 	@printf "\033[33mUsage:\033[0m\n  make [target] [arg=\"val\"...]\n\n\033[33mTargets:\033[0m\n"
@@ -237,6 +241,11 @@ test-visual: PLAYWRIGHT_TEST_TARGET = ./tests/visual
 test-visual: PLAYWRIGHT_TEST_ARGS = --pass-with-no-tests
 test-visual: ## Start Storybook and run visual tests inside a Docker container.
 	@$(MAKE) --no-print-directory run-storybook-playwright PLAYWRIGHT_TEST_TARGET="$(PLAYWRIGHT_TEST_TARGET)" PLAYWRIGHT_TEST_ARGS="$(PLAYWRIGHT_TEST_ARGS)"
+
+test-storybook: PLAYWRIGHT_RUN_CMD = bun scripts/ci/run-storybook-interactions.ts
+test-storybook: PLAYWRIGHT_TEST_TARGET = tests/storybook/interaction-stories.json
+test-storybook: ## Start Storybook and run the story interaction (play function) tests in a Docker container.
+	@$(MAKE) --no-print-directory run-storybook-playwright PLAYWRIGHT_RUN_CMD="$(PLAYWRIGHT_RUN_CMD)" PLAYWRIGHT_TEST_TARGET="$(PLAYWRIGHT_TEST_TARGET)"
 
 up: ## Start the docker hub (Bun).
 	$(DOCKER_COMPOSE) up -d --build

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ locally before pushing. See [agents.md](agents.md) for which test layer a given 
 | `make test-integration` | Jest composition suite: composed components, real children   |
 | `make test-e2e`         | Playwright behavior against a Storybook build                |
 | `make test-visual`      | Playwright visual-regression snapshots                       |
+| `make test-storybook`   | Storybook interaction (play function) tests in a browser     |
 | `make test-mutation`    | Stryker mutation-strength gate                               |
 | `make test-bats`        | Bats coverage of Makefile shell flows and their contracts    |
 
@@ -59,6 +60,20 @@ make test-bats BATS_FORMATTER=tap
 When you add or change a public Make target, update `tests/bats/make-target-coverage.tsv` in the
 same change. Either add or adjust direct Bats coverage for uncovered shell behavior, or point the
 manifest at the pull-request workflow that already exercises the target.
+
+### Storybook interaction tests
+
+Every interactive component ships a story whose `play` function drives it in a real
+browser, so the demonstration surface is also a behavioural gate:
+
+```bash
+make test-storybook
+```
+
+The run fails closed — it exits non-zero when no interaction story is discovered, when
+the live Storybook index and `tests/storybook/interaction-stories.json` disagree, or when
+any registered play test does not pass. See
+[tests/storybook/README.md](tests/storybook/README.md).
 
 ### Dependency graph hygiene
 

--- a/agents.md
+++ b/agents.md
@@ -35,6 +35,7 @@ more than one. Match the change to the suite and run its verification command.
 | Integration       | Composed components rendered with real children | `make test-integration` |
 | End-to-end (e2e)  | Storybook-driven component behavior end to end  | `make test-e2e`         |
 | Visual regression | Any change to rendered UI, layout, or styling   | `make test-visual`      |
+| Interaction       | Behaviour demonstrated by a story `play` fn     | `make test-storybook`   |
 
 Unit tests run on Jest with React Testing Library in a jsdom env; specs are centralized in
 `tests/unit/**/*.test.tsx` (and `*.test.ts` for non-render logic). Integration specs live in
@@ -54,6 +55,13 @@ Storybook is a first-class coverage layer here, not just documentation. Every ne
 component MUST ship stories that render its full state matrix (see Step 2); e2e and visual
 suites run against those stories, so missing states are missing coverage. Provenance for each
 component must also be recorded per `specs/planning-artifacts/architecture.md`.
+
+Interactive components must also DEMONSTRATE their behaviour: add a dedicated story tagged
+`['interaction', '!autodocs']` whose `play` function drives the component with `userEvent` and
+asserts with `expect` (both from `storybook/test`), register it in
+`tests/storybook/interaction-stories.json`, and run `make test-storybook`. Never attach `play`
+to an existing story — Storybook autoplays it, which would destabilise that story's visual
+baseline. See `tests/storybook/README.md`.
 
 Add a specialized suite when the change touches its concern: `make test-mutation` (test
 strength, Stryker), `make test-bats` (Makefile and CI shell flows), `make test-memory-leak`
@@ -122,6 +130,7 @@ make test-unit             # Jest unit suite (jsdom)
 make test-integration      # Jest composition suite (for cross-component changes)
 make test-e2e              # Storybook-driven behavior (for behavior changes)
 make test-visual           # Visual regression (for UI or styling changes)
+make test-storybook        # Story interaction tests (for interactive behavior changes)
 make lint                  # Full gate: ESLint, TypeScript, markdownlint, and format-check
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
         "@storybook/react": "^10.4.2",
         "@storybook/react-webpack5": "^10.4.2",
+        "@storybook/test-runner": "^0.24.4",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/jest-runner": "^9.6.1",
         "@stryker-mutator/typescript": "^4.0.0",
@@ -115,7 +116,7 @@
 
     "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
 
-    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
     "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" } }, "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw=="],
 
@@ -139,9 +140,9 @@
 
     "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-validator-option": ["@babel/helper-validator-option@8.0.0", "", {}, "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q=="],
 
@@ -209,11 +210,11 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
-    "@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
@@ -385,6 +386,10 @@
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
+    "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
+
+    "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -434,6 +439,8 @@
     "@jest/console": ["@jest/console@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "jest-message-util": "30.4.1", "jest-util": "30.4.1", "slash": "^3.0.0" } }, "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA=="],
 
     "@jest/core": ["@jest/core@30.4.2", "", { "dependencies": { "@jest/console": "30.4.1", "@jest/pattern": "30.4.0", "@jest/reporters": "30.4.1", "@jest/test-result": "30.4.1", "@jest/transform": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "ci-info": "^4.2.0", "exit-x": "^0.2.2", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.11", "jest-changed-files": "30.4.1", "jest-config": "30.4.2", "jest-haste-map": "30.4.1", "jest-message-util": "30.4.1", "jest-regex-util": "30.4.0", "jest-resolve": "30.4.1", "jest-resolve-dependencies": "30.4.2", "jest-runner": "30.4.2", "jest-runtime": "30.4.2", "jest-snapshot": "30.4.1", "jest-util": "30.4.1", "jest-validate": "30.4.1", "jest-watcher": "30.4.1", "pretty-format": "30.4.1", "slash": "^3.0.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"] }, "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ=="],
+
+    "@jest/create-cache-key-function": ["@jest/create-cache-key-function@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1" } }, "sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ=="],
 
     "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
 
@@ -679,6 +686,12 @@
 
     "@sentry/utils": ["@sentry/utils@7.120.4", "", { "dependencies": { "@sentry/types": "7.120.4" } }, "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw=="],
 
+    "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
+
+    "@sideway/formula": ["@sideway/formula@3.0.1", "", {}, "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="],
+
+    "@sideway/pinpoint": ["@sideway/pinpoint@2.0.0", "", {}, "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="],
+
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@2.0.0", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0" } }, "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A=="],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@2.0.0", "", {}, "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ=="],
@@ -719,6 +732,8 @@
 
     "@storybook/react-webpack5": ["@storybook/react-webpack5@10.4.3", "", { "dependencies": { "@storybook/builder-webpack5": "10.4.3", "@storybook/preset-react-webpack": "10.4.3", "@storybook/react": "10.4.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.4.3", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-eWcXmRPixExctjT0Z6e5+efYemGfD953L0XkYcHaEXzlQYudZgIpbemknzFmyhkHG32F5DDgL4L5iBuL5A75Jw=="],
 
+    "@storybook/test-runner": ["@storybook/test-runner@0.24.4", "", { "dependencies": { "@babel/core": "^7.22.5", "@babel/generator": "^7.22.5", "@babel/template": "^7.22.5", "@babel/types": "^7.22.5", "@jest/types": "^30.0.1", "@swc/core": "^1.5.22", "@swc/jest": "^0.2.38", "expect-playwright": "^0.8.0", "jest": "^30.0.4", "jest-circus": "^30.0.4", "jest-environment-node": "^30.0.4", "jest-junit": "^16.0.0", "jest-process-manager": "^0.4.0", "jest-runner": "^30.0.4", "jest-serializer-html": "^7.1.0", "jest-watch-typeahead": "^3.0.1", "nyc": "^15.1.0", "playwright": "^1.14.0", "playwright-core": ">=1.2.0", "rimraf": "^3.0.2", "uuid": "^8.3.2" }, "peerDependencies": { "storybook": "^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0" }, "bin": { "test-storybook": "dist/test-storybook.js" } }, "sha512-xm04bba5N7QyHHc+wD4xmPZx0vKK/PIpmTFypy445HrWOj0nFK4pYg5dE6H4ppqMt7qZAnb5GfHTvBwJtywJ4A=="],
+
     "@stryker-mutator/api": ["@stryker-mutator/api@9.6.1", "", { "dependencies": { "mutation-testing-metrics": "3.7.3", "mutation-testing-report-schema": "3.7.3", "tslib": "~2.8.0", "typed-inject": "~5.0.0" } }, "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg=="],
 
     "@stryker-mutator/core": ["@stryker-mutator/core@9.6.1", "", { "dependencies": { "@inquirer/prompts": "^8.0.0", "@stryker-mutator/api": "9.6.1", "@stryker-mutator/instrumenter": "9.6.1", "@stryker-mutator/util": "9.6.1", "ajv": "~8.18.0", "chalk": "~5.6.0", "commander": "~14.0.0", "diff-match-patch": "1.0.5", "emoji-regex": "~10.6.0", "execa": "~9.6.0", "json-rpc-2.0": "^1.7.0", "lodash.groupby": "~4.6.0", "minimatch": "~10.2.4", "mutation-server-protocol": "~0.4.0", "mutation-testing-elements": "3.7.3", "mutation-testing-metrics": "3.7.3", "mutation-testing-report-schema": "3.7.3", "npm-run-path": "~6.0.0", "progress": "~2.0.3", "rxjs": "~7.8.1", "semver": "^7.6.3", "source-map": "~0.7.4", "tree-kill": "~1.2.2", "tslib": "2.8.1", "typed-inject": "~5.0.0", "typed-rest-client": "~2.3.0" }, "bin": { "stryker": "bin/stryker.js" } }, "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ=="],
@@ -758,6 +773,8 @@
     "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.24", "", { "os": "win32", "cpu": "x64" }, "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ=="],
 
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
+    "@swc/jest": ["@swc/jest@0.2.39", "", { "dependencies": { "@jest/create-cache-key-function": "^30.0.0", "@swc/counter": "^0.1.3", "jsonc-parser": "^3.2.0" }, "peerDependencies": { "@swc/core": "*" } }, "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA=="],
 
     "@swc/types": ["@swc/types@0.1.26", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw=="],
 
@@ -860,6 +877,8 @@
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "@types/wait-on": ["@types/wait-on@5.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
@@ -995,6 +1014,8 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
@@ -1018,6 +1039,10 @@
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "append-transform": ["append-transform@2.0.0", "", { "dependencies": { "default-require-extensions": "^3.0.0" } }, "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg=="],
+
+    "archy": ["archy@1.0.0", "", {}, "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="],
 
     "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
@@ -1067,11 +1092,15 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "atob": ["atob@2.1.2", "", { "bin": { "atob": "bin/atob.js" } }, "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.11.2", "", {}, "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw=="],
+
+    "axios": ["axios@1.19.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.6", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1141,6 +1170,8 @@
 
     "cache-base": ["cache-base@1.0.1", "", { "dependencies": { "collection-visit": "^1.0.0", "component-emitter": "^1.2.1", "get-value": "^2.0.6", "has-value": "^1.0.0", "isobject": "^3.0.1", "set-value": "^2.0.0", "to-object-path": "^0.3.0", "union-value": "^1.0.0", "unset-value": "^1.0.0" } }, "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ=="],
 
+    "caching-transform": ["caching-transform@4.0.0", "", { "dependencies": { "hasha": "^5.0.0", "make-dir": "^3.0.0", "package-hash": "^4.0.0", "write-file-atomic": "^3.0.0" } }, "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA=="],
+
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -1193,6 +1224,8 @@
 
     "clean-css": ["clean-css@5.3.3", "", { "dependencies": { "source-map": "~0.6.0" } }, "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg=="],
 
+    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
+
     "cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
 
     "cli-width": ["cli-width@2.2.1", "", {}, "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="],
@@ -1214,6 +1247,8 @@
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "colors": ["colors@1.4.0", "", {}, "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
@@ -1273,6 +1308,8 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cwd": ["cwd@0.10.0", "", { "dependencies": { "find-pkg": "^0.1.2", "fs-exists-sync": "^0.1.0" } }, "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
@@ -1295,7 +1332,7 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
-    "dedent": ["dedent@0.7.0", "", {}, "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="],
+    "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
@@ -1309,6 +1346,8 @@
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
+    "default-require-extensions": ["default-require-extensions@3.0.1", "", { "dependencies": { "strip-bom": "^4.0.0" } }, "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw=="],
+
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
@@ -1318,6 +1357,8 @@
     "define-property": ["define-property@2.0.2", "", { "dependencies": { "is-descriptor": "^1.0.2", "isobject": "^3.0.1" } }, "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1339,6 +1380,8 @@
 
     "diff-match-patch": ["diff-match-patch@1.0.5", "", {}, "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="],
 
+    "diffable-html": ["diffable-html@4.1.0", "", { "dependencies": { "htmlparser2": "^3.9.2" } }, "sha512-++kyNek+YBLH8cLXS+iTj/Hiy2s5qkRJEJ8kgu/WHbFrVY2vz9xPFUT+fii2zGF0m1CaojDlQJjkfrCt7YWM1g=="],
+
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
@@ -1347,13 +1390,13 @@
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
-    "dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
+    "dom-serializer": ["dom-serializer@0.2.2", "", { "dependencies": { "domelementtype": "^2.0.1", "entities": "^2.0.0" } }, "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g=="],
 
-    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+    "domelementtype": ["domelementtype@1.3.1", "", {}, "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="],
 
-    "domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
+    "domhandler": ["domhandler@2.4.2", "", { "dependencies": { "domelementtype": "1" } }, "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA=="],
 
-    "domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
+    "domutils": ["domutils@1.7.0", "", { "dependencies": { "dom-serializer": "0", "domelementtype": "1" } }, "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg=="],
 
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
@@ -1387,6 +1430,8 @@
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
@@ -1410,6 +1455,8 @@
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
 
     "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
@@ -1477,11 +1524,17 @@
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
+    "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
+
     "exit-x": ["exit-x@0.2.2", "", {}, "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ=="],
 
     "expand-brackets": ["expand-brackets@2.1.4", "", { "dependencies": { "debug": "^2.3.3", "define-property": "^0.2.5", "extend-shallow": "^2.0.1", "posix-character-classes": "^0.1.0", "regex-not": "^1.0.0", "snapdragon": "^0.8.1", "to-regex": "^3.0.1" } }, "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA=="],
 
+    "expand-tilde": ["expand-tilde@1.2.2", "", { "dependencies": { "os-homedir": "^1.0.1" } }, "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q=="],
+
     "expect": ["expect@30.4.1", "", { "dependencies": { "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA=="],
+
+    "expect-playwright": ["expect-playwright@0.8.0", "", {}, "sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg=="],
 
     "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
 
@@ -1527,6 +1580,12 @@
 
     "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
 
+    "find-file-up": ["find-file-up@0.1.3", "", { "dependencies": { "fs-exists-sync": "^0.1.0", "resolve-dir": "^0.1.0" } }, "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A=="],
+
+    "find-pkg": ["find-pkg@0.1.2", "", { "dependencies": { "find-file-up": "^0.1.2" } }, "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw=="],
+
+    "find-process": ["find-process@1.4.11", "", { "dependencies": { "chalk": "~4.1.2", "commander": "^12.1.0", "loglevel": "^1.9.2" }, "bin": { "find-process": "bin/find-process.js" } }, "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA=="],
+
     "find-root": ["find-root@1.1.0", "", {}, "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
@@ -1535,19 +1594,27 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "for-in": ["for-in@1.0.2", "", {}, "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="],
 
-    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+    "foreground-child": ["foreground-child@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "signal-exit": "^3.0.2" } }, "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA=="],
 
     "fork-ts-checker-webpack-plugin": ["fork-ts-checker-webpack-plugin@9.1.0", "", { "dependencies": { "@babel/code-frame": "^7.16.7", "chalk": "^4.1.2", "chokidar": "^4.0.1", "cosmiconfig": "^8.2.0", "deepmerge": "^4.2.2", "fs-extra": "^10.0.0", "memfs": "^3.4.1", "minimatch": "^3.0.4", "node-abort-controller": "^3.0.1", "schema-utils": "^3.1.1", "semver": "^7.3.5", "tapable": "^2.2.1" }, "peerDependencies": { "typescript": ">3.6.0", "webpack": "^5.11.0" } }, "sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q=="],
+
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fragment-cache": ["fragment-cache@0.2.1", "", { "dependencies": { "map-cache": "^0.2.2" } }, "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA=="],
 
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fromentries": ["fromentries@1.3.2", "", {}, "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="],
+
+    "fs-exists-sync": ["fs-exists-sync@0.1.0", "", {}, "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg=="],
 
     "fs-extra": ["fs-extra@4.0.3", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg=="],
 
@@ -1595,6 +1662,10 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
+    "global-modules": ["global-modules@0.2.3", "", { "dependencies": { "global-prefix": "^0.1.4", "is-windows": "^0.2.0" } }, "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA=="],
+
+    "global-prefix": ["global-prefix@0.1.5", "", { "dependencies": { "homedir-polyfill": "^1.0.0", "ini": "^1.3.4", "is-windows": "^0.2.0", "which": "^1.2.12" } }, "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw=="],
+
     "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
@@ -1625,6 +1696,8 @@
 
     "has-values": ["has-values@1.0.0", "", { "dependencies": { "is-number": "^3.0.0", "kind-of": "^4.0.0" } }, "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ=="],
 
+    "hasha": ["hasha@5.2.2", "", { "dependencies": { "is-stream": "^2.0.0", "type-fest": "^0.8.0" } }, "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
@@ -1634,6 +1707,8 @@
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
+
+    "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
@@ -1647,7 +1722,7 @@
 
     "html-webpack-plugin": ["html-webpack-plugin@5.6.6", "", { "dependencies": { "@types/html-minifier-terser": "^6.0.0", "html-minifier-terser": "^6.0.2", "lodash": "^4.17.21", "pretty-error": "^4.0.0", "tapable": "^2.0.0" }, "peerDependencies": { "@rspack/core": "0.x || 1.x", "webpack": "^5.20.0" }, "optionalPeers": ["@rspack/core", "webpack"] }, "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw=="],
 
-    "htmlparser2": ["htmlparser2@6.1.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.0.0", "domutils": "^2.5.2", "entities": "^2.0.0" } }, "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A=="],
+    "htmlparser2": ["htmlparser2@3.10.1", "", { "dependencies": { "domelementtype": "^1.3.1", "domhandler": "^2.3.0", "domutils": "^1.5.1", "entities": "^1.1.1", "inherits": "^2.0.1", "readable-stream": "^3.1.1" } }, "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1817,11 +1892,15 @@
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
-    "istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
+    "istanbul-lib-hook": ["istanbul-lib-hook@3.0.0", "", { "dependencies": { "append-transform": "^2.0.0" } }, "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ=="],
+
+    "istanbul-lib-instrument": ["istanbul-lib-instrument@4.0.3", "", { "dependencies": { "@babel/core": "^7.7.5", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.0.0", "semver": "^6.3.0" } }, "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ=="],
+
+    "istanbul-lib-processinfo": ["istanbul-lib-processinfo@2.0.3", "", { "dependencies": { "archy": "^1.0.0", "cross-spawn": "^7.0.3", "istanbul-lib-coverage": "^3.2.0", "p-map": "^3.0.0", "rimraf": "^3.0.0", "uuid": "^8.3.2" } }, "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg=="],
 
     "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
 
-    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@4.0.1", "", { "dependencies": { "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0", "source-map": "^0.6.1" } }, "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw=="],
 
     "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
@@ -1851,6 +1930,8 @@
 
     "jest-haste-map": ["jest-haste-map@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "anymatch": "^3.1.3", "fb-watchman": "^2.0.2", "graceful-fs": "^4.2.11", "jest-regex-util": "30.4.0", "jest-util": "30.4.1", "jest-worker": "30.4.1", "picomatch": "^4.0.3", "walker": "^1.0.8" }, "optionalDependencies": { "fsevents": "^2.3.3" } }, "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw=="],
 
+    "jest-junit": ["jest-junit@16.0.0", "", { "dependencies": { "mkdirp": "^1.0.4", "strip-ansi": "^6.0.1", "uuid": "^8.3.2", "xml": "^1.0.1" } }, "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ=="],
+
     "jest-leak-detector": ["jest-leak-detector@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "pretty-format": "30.4.1" } }, "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ=="],
 
     "jest-matcher-utils": ["jest-matcher-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.4.1", "pretty-format": "30.4.1" } }, "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A=="],
@@ -1860,6 +1941,8 @@
     "jest-mock": ["jest-mock@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "jest-util": "30.4.1" } }, "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw=="],
 
     "jest-pnp-resolver": ["jest-pnp-resolver@1.2.3", "", { "peerDependencies": { "jest-resolve": "*" }, "optionalPeers": ["jest-resolve"] }, "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="],
+
+    "jest-process-manager": ["jest-process-manager@0.4.0", "", { "dependencies": { "@types/wait-on": "^5.2.0", "chalk": "^4.1.0", "cwd": "^0.10.0", "exit": "^0.1.2", "find-process": "^1.4.4", "prompts": "^2.4.1", "signal-exit": "^3.0.3", "spawnd": "^5.0.0", "tree-kill": "^1.2.2", "wait-on": "^7.0.0" } }, "sha512-80Y6snDyb0p8GG83pDxGI/kQzwVTkCxc7ep5FPe/F6JYdvRDhwr6RzRmPSP7SEwuLhxo80lBS/NqOdUIbHIfhw=="],
 
     "jest-regex-util": ["jest-regex-util@30.4.0", "", {}, "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg=="],
 
@@ -1873,11 +1956,15 @@
 
     "jest-serializer": ["jest-serializer@26.6.2", "", { "dependencies": { "@types/node": "*", "graceful-fs": "^4.2.4" } }, "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g=="],
 
+    "jest-serializer-html": ["jest-serializer-html@7.1.0", "", { "dependencies": { "diffable-html": "^4.1.0" } }, "sha512-xYL2qC7kmoYHJo8MYqJkzrl/Fdlx+fat4U1AqYg+kafqwcKPiMkOcjWHPKhueuNEgr+uemhGc+jqXYiwCyRyLA=="],
+
     "jest-snapshot": ["jest-snapshot@30.4.1", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/generator": "^7.27.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/types": "^7.27.3", "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "@jest/snapshot-utils": "30.4.1", "@jest/transform": "30.4.1", "@jest/types": "30.4.1", "babel-preset-current-node-syntax": "^1.2.0", "chalk": "^4.1.2", "expect": "30.4.1", "graceful-fs": "^4.2.11", "jest-diff": "30.4.1", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-util": "30.4.1", "pretty-format": "30.4.1", "semver": "^7.7.2", "synckit": "^0.11.8" } }, "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw=="],
 
     "jest-util": ["jest-util@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA=="],
 
     "jest-validate": ["jest-validate@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "@jest/types": "30.4.1", "camelcase": "^6.3.0", "chalk": "^4.1.2", "leven": "^3.1.0", "pretty-format": "30.4.1" } }, "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw=="],
+
+    "jest-watch-typeahead": ["jest-watch-typeahead@3.0.1", "", { "dependencies": { "ansi-escapes": "^7.0.0", "chalk": "^5.2.0", "jest-regex-util": "^30.0.0", "jest-watcher": "^30.0.0", "slash": "^5.0.0", "string-length": "^6.0.0", "strip-ansi": "^7.0.1" }, "peerDependencies": { "jest": "^30.0.0" } }, "sha512-SFmHcvdueTswZlVhPCWfLXMazvwZlA2UZTrcE7MC3NwEVeWvEcOx6HUe+igMbnmA6qowuBSW4in8iC6J2EYsgQ=="],
 
     "jest-watcher": ["jest-watcher@30.4.1", "", { "dependencies": { "@jest/test-result": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "emittery": "^0.13.1", "jest-util": "30.4.1", "string-length": "^4.0.2" } }, "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw=="],
 
@@ -1886,6 +1973,8 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
+
+    "joi": ["joi@17.13.4", "", { "dependencies": { "@hapi/hoek": "^9.3.0", "@hapi/topo": "^5.1.0", "@sideway/address": "^4.1.5", "@sideway/formula": "^3.0.1", "@sideway/pinpoint": "^2.0.0" } }, "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ=="],
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
@@ -1967,11 +2056,15 @@
 
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
+    "lodash.flattendeep": ["lodash.flattendeep@4.4.0", "", {}, "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="],
+
     "lodash.groupby": ["lodash.groupby@4.6.0", "", {}, "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="],
 
     "lodash.memoize": ["lodash.memoize@4.1.2", "", {}, "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
 
     "lookup-closest-locale": ["lookup-closest-locale@6.2.0", "", {}, "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ=="],
 
@@ -2147,6 +2240,8 @@
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
+    "node-preload": ["node-preload@0.2.1", "", { "dependencies": { "process-on-spawn": "^1.0.0" } }, "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ=="],
+
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
@@ -2156,6 +2251,8 @@
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
+    "nyc": ["nyc@15.1.0", "", { "dependencies": { "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.2", "caching-transform": "^4.0.0", "convert-source-map": "^1.7.0", "decamelize": "^1.2.0", "find-cache-dir": "^3.2.0", "find-up": "^4.1.0", "foreground-child": "^2.0.0", "get-package-type": "^0.1.0", "glob": "^7.1.6", "istanbul-lib-coverage": "^3.0.0", "istanbul-lib-hook": "^3.0.0", "istanbul-lib-instrument": "^4.0.0", "istanbul-lib-processinfo": "^2.0.2", "istanbul-lib-report": "^3.0.0", "istanbul-lib-source-maps": "^4.0.0", "istanbul-reports": "^3.0.2", "make-dir": "^3.0.0", "node-preload": "^0.2.1", "p-map": "^3.0.0", "process-on-spawn": "^1.0.0", "resolve-from": "^5.0.0", "rimraf": "^3.0.0", "signal-exit": "^3.0.2", "spawn-wrap": "^2.0.0", "test-exclude": "^6.0.0", "yargs": "^15.0.2" }, "bin": { "nyc": "bin/nyc.js" } }, "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -2199,6 +2296,8 @@
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
+    "os-homedir": ["os-homedir@1.0.2", "", {}, "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ=="],
+
     "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -2213,11 +2312,15 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "p-map": ["p-map@3.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "package-hash": ["package-hash@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.15", "hasha": "^5.0.0", "lodash.flattendeep": "^4.4.0", "release-zalgo": "^1.0.0" } }, "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
@@ -2232,6 +2335,8 @@
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
+    "parse-passwd": ["parse-passwd@1.0.0", "", {}, "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -2299,6 +2404,8 @@
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
+    "process-on-spawn": ["process-on-spawn@1.1.0", "", { "dependencies": { "fromentries": "^1.2.0" } }, "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -2349,6 +2456,8 @@
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
@@ -2366,6 +2475,8 @@
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "relateurl": ["relateurl@0.2.7", "", {}, "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="],
+
+    "release-zalgo": ["release-zalgo@1.0.0", "", { "dependencies": { "es6-error": "^4.0.1" } }, "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA=="],
 
     "remove-trailing-separator": ["remove-trailing-separator@1.1.0", "", {}, "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="],
 
@@ -2390,6 +2501,8 @@
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
+
+    "resolve-dir": ["resolve-dir@0.1.1", "", { "dependencies": { "expand-tilde": "^1.2.2", "global-modules": "^0.2.3" } }, "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -2469,7 +2582,7 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -2497,9 +2610,13 @@
 
     "source-map-resolve": ["source-map-resolve@0.5.3", "", { "dependencies": { "atob": "^2.1.2", "decode-uri-component": "^0.2.0", "resolve-url": "^0.2.1", "source-map-url": "^0.4.0", "urix": "^0.1.0" } }, "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw=="],
 
-    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+    "source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
     "source-map-url": ["source-map-url@0.4.1", "", {}, "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="],
+
+    "spawn-wrap": ["spawn-wrap@2.0.0", "", { "dependencies": { "foreground-child": "^2.0.0", "is-windows": "^1.0.2", "make-dir": "^3.0.0", "rimraf": "^3.0.0", "signal-exit": "^3.0.2", "which": "^2.0.1" } }, "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg=="],
+
+    "spawnd": ["spawnd@5.0.0", "", { "dependencies": { "exit": "^0.1.2", "signal-exit": "^3.0.3", "tree-kill": "^1.2.2", "wait-port": "^0.2.9" } }, "sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA=="],
 
     "speedline-core": ["speedline-core@1.4.3", "", { "dependencies": { "@types/node": "*", "image-ssim": "^0.2.0", "jpeg-js": "^0.4.1" } }, "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog=="],
 
@@ -2523,7 +2640,7 @@
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
+    "string-length": ["string-length@6.0.0", "", { "dependencies": { "strip-ansi": "^7.1.0" } }, "sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2540,6 +2657,8 @@
     "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
@@ -2721,6 +2840,10 @@
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
+    "wait-on": ["wait-on@7.2.0", "", { "dependencies": { "axios": "^1.6.1", "joi": "^17.11.0", "lodash": "^4.17.21", "minimist": "^1.2.8", "rxjs": "^7.8.1" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ=="],
+
+    "wait-port": ["wait-port@0.2.14", "", { "dependencies": { "chalk": "^2.4.2", "commander": "^3.0.2", "debug": "^4.1.1" }, "bin": { "wait-port": "bin/wait-port.js" } }, "sha512-kIzjWcr6ykl7WFbZd0TMae8xovwqcqbx6FM9l+7agOgUByhzdjfzZBPK2CPufldTOMxbUivss//Sh9MFawmPRQ=="],
+
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
     "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
@@ -2783,6 +2906,8 @@
 
     "xdg-basedir": ["xdg-basedir@4.0.0", "", {}, "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="],
 
+    "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
+
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
@@ -2819,11 +2944,17 @@
 
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@babel/core/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/core/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
     "@babel/core/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/generator/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+    "@babel/generator/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
 
@@ -2839,21 +2970,19 @@
 
     "@babel/helper-member-expression-to-functions/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
-    "@babel/helper-member-expression-to-functions/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
     "@babel/helper-module-imports/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/helper-module-imports/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
 
     "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/helper-optimise-call-expression/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
     "@babel/helper-replace-supers/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+    "@babel/helpers/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/helpers/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
@@ -2903,6 +3032,8 @@
 
     "@babel/plugin-transform-modules-commonjs/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
 
+    "@babel/plugin-transform-react-jsx/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
     "@babel/plugin-transform-typescript/@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/helper-replace-supers": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/traverse": "^7.28.6", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow=="],
@@ -2917,7 +3048,13 @@
 
     "@babel/preset-typescript/@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
 
-    "@babel/template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/template/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/traverse/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/traverse/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
@@ -2946,6 +3083,8 @@
     "@inquirer/core/cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "@inquirer/core/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
+    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@inquirer/external-editor/chardet": ["chardet@2.2.0", "", {}, "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="],
 
@@ -2981,9 +3120,13 @@
 
     "@jest/reporters/istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
 
+    "@jest/reporters/istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
     "@jest/reporters/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
 
     "@jest/reporters/jest-worker": ["jest-worker@30.4.1", "", { "dependencies": { "@types/node": "*", "@ungap/structured-clone": "^1.3.0", "jest-util": "30.4.1", "merge-stream": "^2.0.0", "supports-color": "^8.1.1" } }, "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g=="],
+
+    "@jest/reporters/string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
 
     "@jest/transform/@jest/types": ["@jest/types@26.6.2", "", { "dependencies": { "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^15.0.0", "chalk": "^4.0.0" } }, "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ=="],
 
@@ -2999,11 +3142,7 @@
 
     "@lhci/utils/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "@memlab/e2e/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
-
     "@memlab/e2e/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
-
-    "@memlab/e2e/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
     "@memlab/e2e/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
@@ -3065,8 +3204,6 @@
 
     "@stryker-mutator/core/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
-    "@stryker-mutator/instrumenter/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
-
     "@stryker-mutator/instrumenter/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
@@ -3111,9 +3248,17 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "axios/proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
     "babel-jest/@jest/types": ["@jest/types@26.6.2", "", { "dependencies": { "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^15.0.0", "chalk": "^4.0.0" } }, "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ=="],
 
     "babel-plugin-istanbul/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
+
+    "babel-plugin-jest-hoist/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "babel-plugin-jest-hoist/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
@@ -3143,6 +3288,12 @@
 
     "css-loader/semver": ["semver@7.8.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg=="],
 
+    "css-select/domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
+
+    "css-select/domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
+
+    "default-require-extensions/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
+
     "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
     "dependency-cruiser/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
@@ -3151,7 +3302,11 @@
 
     "dependency-cruiser/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
     "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "endent/dedent": ["dedent@0.7.0", "", {}, "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="],
 
     "enhanced-resolve/tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -3187,6 +3342,8 @@
 
     "execa/figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
+    "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "expand-brackets/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "expand-brackets/define-property": ["define-property@0.2.5", "", { "dependencies": { "is-descriptor": "^0.1.0" } }, "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA=="],
@@ -3209,6 +3366,8 @@
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "find-process/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "fork-ts-checker-webpack-plugin/cosmiconfig": ["cosmiconfig@8.3.6", "", { "dependencies": { "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0", "path-type": "^4.0.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA=="],
 
     "fork-ts-checker-webpack-plugin/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
@@ -3217,17 +3376,31 @@
 
     "fork-ts-checker-webpack-plugin/semver": ["semver@7.8.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg=="],
 
+    "form-data/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
+    "global-modules/is-windows": ["is-windows@0.2.0", "", {}, "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q=="],
+
+    "global-prefix/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "global-prefix/is-windows": ["is-windows@0.2.0", "", {}, "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q=="],
+
+    "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "has-values/is-number": ["is-number@3.0.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg=="],
 
     "has-values/kind-of": ["kind-of@4.0.0", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw=="],
 
+    "hasha/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "hasha/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
+
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "html-minifier-terser/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
-    "htmlparser2/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+    "htmlparser2/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
 
     "import-in-the-middle/es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
@@ -3248,8 +3421,6 @@
     "jest-changed-files/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "jest-changed-files/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
-
-    "jest-circus/dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
     "jest-circus/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
 
@@ -3275,6 +3446,8 @@
 
     "jest-haste-map/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "jest-junit/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "jest-message-util/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
@@ -3291,8 +3464,6 @@
 
     "jest-runner/jest-worker": ["jest-worker@30.4.1", "", { "dependencies": { "@types/node": "*", "@ungap/structured-clone": "^1.3.0", "jest-util": "30.4.1", "merge-stream": "^2.0.0", "supports-color": "^8.1.1" } }, "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g=="],
 
-    "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
-
     "jest-runtime/@jest/transform": ["@jest/transform@30.4.1", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/types": "30.4.1", "@jridgewell/trace-mapping": "^0.3.25", "babel-plugin-istanbul": "^7.0.1", "chalk": "^4.1.2", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.4.1", "jest-regex-util": "30.4.0", "jest-util": "30.4.1", "pirates": "^4.0.7", "slash": "^3.0.0", "write-file-atomic": "^5.0.1" } }, "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ=="],
 
     "jest-runtime/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -3303,11 +3474,7 @@
 
     "jest-serializer/@types/node": ["@types/node@18.11.9", "", {}, "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="],
 
-    "jest-snapshot/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
-
     "jest-snapshot/@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
-
-    "jest-snapshot/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "jest-snapshot/@jest/transform": ["@jest/transform@30.4.1", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/types": "30.4.1", "@jridgewell/trace-mapping": "^0.3.25", "babel-plugin-istanbul": "^7.0.1", "chalk": "^4.1.2", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.4.1", "jest-regex-util": "30.4.0", "jest-util": "30.4.1", "pirates": "^4.0.7", "slash": "^3.0.0", "write-file-atomic": "^5.0.1" } }, "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ=="],
 
@@ -3325,9 +3492,19 @@
 
     "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
+    "jest-watch-typeahead/ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "jest-watch-typeahead/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "jest-watch-typeahead/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
+
+    "jest-watch-typeahead/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "jest-watcher/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "jest-watcher/jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
+
+    "jest-watcher/string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
 
     "jest-worker/@types/node": ["@types/node@18.11.9", "", {}, "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="],
 
@@ -3377,6 +3554,14 @@
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
+    "nyc/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+
+    "nyc/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "nyc/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "nyc/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
     "object-copy/define-property": ["define-property@0.2.5", "", { "dependencies": { "is-descriptor": "^0.1.0" } }, "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA=="],
 
     "object-copy/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
@@ -3403,11 +3588,11 @@
 
     "regex-not/safe-regex": ["safe-regex@1.1.0", "", { "dependencies": { "ret": "~0.1.10" } }, "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg=="],
 
+    "renderkid/htmlparser2": ["htmlparser2@6.1.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.0.0", "domutils": "^2.5.2", "entities": "^2.0.0" } }, "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A=="],
+
     "renderkid/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sane/anymatch": ["anymatch@2.0.0", "", { "dependencies": { "micromatch": "^3.1.4", "normalize-path": "^2.1.1" } }, "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw=="],
 
@@ -3451,7 +3636,7 @@
 
     "storybook/semver": ["semver@7.8.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg=="],
 
-    "string-length/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "string-length/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -3466,6 +3651,8 @@
     "terser/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "terser/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
@@ -3501,6 +3688,10 @@
 
     "unset-value/has-value": ["has-value@0.3.1", "", { "dependencies": { "get-value": "^2.0.3", "has-values": "^0.1.4", "isobject": "^2.0.0" } }, "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q=="],
 
+    "wait-port/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
+
+    "wait-port/commander": ["commander@3.0.2", "", {}, "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="],
+
     "webpack/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "webpack/enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
@@ -3519,8 +3710,6 @@
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
@@ -3531,39 +3720,23 @@
 
     "@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+    "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
-    "@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/helper-annotate-as-pure/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
-
-    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
-    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
-
-    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
     "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
     "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -3575,37 +3748,23 @@
 
     "@babel/helper-module-imports/@babel/traverse/@babel/template": ["@babel/template@8.0.0", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ=="],
 
+    "@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
+
+    "@babel/helper-module-imports/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
+
     "@babel/helper-module-transforms/@babel/helper-module-imports/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-optimise-call-expression/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
     "@babel/helper-replace-supers/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
-
-    "@babel/helper-replace-supers/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
     "@babel/helper-replace-supers/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/helper-replace-supers/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
-    "@babel/helper-replace-supers/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
-
-    "@babel/helper-replace-supers/@babel/traverse/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/helpers/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -3617,15 +3776,13 @@
 
     "@babel/plugin-transform-destructuring/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
-    "@babel/plugin-transform-destructuring/@babel/traverse/@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
-
     "@babel/plugin-transform-destructuring/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/plugin-transform-destructuring/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
-    "@babel/plugin-transform-destructuring/@babel/traverse/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+    "@babel/plugin-transform-react-jsx/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
-    "@babel/plugin-transform-destructuring/@babel/traverse/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+    "@babel/plugin-transform-react-jsx/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
@@ -3638,10 +3795,6 @@
     "@babel/plugin-transform-typescript/@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-skip-transparent-expression-wrappers/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -3681,11 +3834,15 @@
 
     "@jest/reporters/@jest/transform/write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
+    "@jest/reporters/glob/foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "@jest/reporters/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@jest/reporters/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@jest/reporters/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "@jest/reporters/string-length/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@jest/transform/@jest/types/@types/node": ["@types/node@18.11.9", "", {}, "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="],
 
@@ -3709,19 +3866,9 @@
 
     "@lhci/utils/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "@memlab/e2e/@babel/generator/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
-    "@memlab/e2e/@babel/parser/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
-    "@memlab/e2e/@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
-
-    "@memlab/e2e/@babel/template/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
     "@memlab/e2e/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
     "@memlab/e2e/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
-
-    "@memlab/e2e/@babel/traverse/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@microsoft/api-extractor/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -3748,10 +3895,6 @@
     "@stryker-mutator/core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@stryker-mutator/core/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
-
-    "@stryker-mutator/instrumenter/@babel/generator/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
-    "@stryker-mutator/instrumenter/@babel/parser/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@testing-library/dom/pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -3783,9 +3926,13 @@
 
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "babel-jest/@jest/types/@types/node": ["@types/node@18.11.9", "", {}, "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="],
 
     "babel-jest/@jest/types/@types/yargs": ["@types/yargs@15.0.20", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg=="],
+
+    "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "babel-plugin-jest-hoist/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -3798,6 +3945,12 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "css-select/domhandler/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
+
+    "css-select/domutils/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -3863,8 +4016,6 @@
 
     "jest-changed-files/execa/onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "jest-changed-files/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
     "jest-changed-files/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "jest-changed-files/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -3883,6 +4034,8 @@
 
     "jest-config/babel-jest/babel-preset-jest": ["babel-preset-jest@30.4.0", "", { "dependencies": { "babel-plugin-jest-hoist": "30.4.0", "babel-preset-current-node-syntax": "^1.2.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-beta.1" } }, "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg=="],
 
+    "jest-config/glob/foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "jest-config/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "jest-config/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -3893,7 +4046,7 @@
 
     "jest-haste-map/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
-    "jest-message-util/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+    "jest-junit/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "jest-mock/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
@@ -3911,17 +4064,13 @@
 
     "jest-runtime/@jest/transform/write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
+    "jest-runtime/glob/foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "jest-runtime/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "jest-runtime/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "jest-snapshot/@babel/generator/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
-
     "jest-snapshot/@babel/plugin-syntax-jsx/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
-
-    "jest-snapshot/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "jest-snapshot/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "jest-snapshot/@jest/transform/babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
 
@@ -3931,9 +4080,13 @@
 
     "jest-util/@jest/types/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
+    "jest-watch-typeahead/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "jest-watcher/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "jest-watcher/jest-util/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "jest-watcher/string-length/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -3955,6 +4108,14 @@
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "nyc/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "nyc/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "nyc/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "nyc/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+
     "object-copy/define-property/is-descriptor": ["is-descriptor@0.1.7", "", { "dependencies": { "is-accessor-descriptor": "^1.0.1", "is-data-descriptor": "^1.0.1" } }, "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg=="],
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
@@ -3962,6 +4123,14 @@
     "react-docgen/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "react-docgen/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "renderkid/htmlparser2/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "renderkid/htmlparser2/domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
+
+    "renderkid/htmlparser2/domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
+
+    "renderkid/htmlparser2/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "renderkid/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -3974,8 +4143,6 @@
     "sane/execa/is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
 
     "sane/execa/npm-run-path": ["npm-run-path@2.0.2", "", { "dependencies": { "path-key": "^2.0.0" } }, "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw=="],
-
-    "sane/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sane/micromatch/braces": ["braces@2.3.2", "", { "dependencies": { "arr-flatten": "^1.1.0", "array-unique": "^0.3.2", "extend-shallow": "^2.0.1", "fill-range": "^4.0.0", "isobject": "^3.0.1", "repeat-element": "^1.1.2", "snapdragon": "^0.8.1", "snapdragon-node": "^2.0.1", "split-string": "^3.0.2", "to-regex": "^3.0.1" } }, "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w=="],
 
@@ -4041,7 +4208,7 @@
 
     "storybook/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.23.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg=="],
 
-    "string-length/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "string-length/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -4050,6 +4217,12 @@
     "unset-value/has-value/has-values": ["has-values@0.1.4", "", {}, "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ=="],
 
     "unset-value/has-value/isobject": ["isobject@2.1.0", "", { "dependencies": { "isarray": "1.0.0" } }, "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA=="],
+
+    "wait-port/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "wait-port/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "wait-port/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "webpack-hot-middleware/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -4061,35 +4234,11 @@
 
     "yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/helper-member-expression-to-functions/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+    "@babel/helper-module-imports/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "@babel/helper-module-transforms/@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@babel/helper-replace-supers/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/helper-replace-supers/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-replace-supers/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/plugin-transform-destructuring/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/plugin-transform-destructuring/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/plugin-transform-destructuring/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-annotate-as-pure/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -4113,35 +4262,23 @@
 
     "@jest/core/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
 
+    "@jest/core/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "@jest/reporters/@jest/transform/babel-plugin-istanbul/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
+    "@jest/reporters/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "@jest/reporters/glob/foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "@jest/reporters/glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
+
+    "@jest/reporters/string-length/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@lhci/cli/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@lhci/cli/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@lhci/cli/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "@memlab/e2e/@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@memlab/e2e/@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@memlab/e2e/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@memlab/e2e/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@memlab/e2e/@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@memlab/e2e/@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@memlab/e2e/@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@memlab/e2e/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@memlab/e2e/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@memlab/e2e/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@microsoft/api-extractor/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -4155,15 +4292,9 @@
 
     "@stryker-mutator/core/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "@stryker-mutator/instrumenter/@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@stryker-mutator/instrumenter/@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@stryker-mutator/instrumenter/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@stryker-mutator/instrumenter/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "eslint-plugin-storybook/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ=="],
 
@@ -4207,15 +4338,23 @@
 
     "jest-config/babel-jest/babel-preset-jest/babel-plugin-jest-hoist": ["babel-plugin-jest-hoist@30.4.0", "", { "dependencies": { "@types/babel__core": "^7.20.5" } }, "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA=="],
 
+    "jest-config/glob/foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "jest-runner/@jest/transform/babel-plugin-istanbul/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
     "jest-runner/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
 
+    "jest-runner/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "jest-runtime/@jest/transform/babel-plugin-istanbul/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
     "jest-runtime/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
+
+    "jest-runtime/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "jest-runtime/glob/foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "jest-runtime/glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
@@ -4223,7 +4362,11 @@
 
     "jest-snapshot/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
 
+    "jest-snapshot/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "jest-util/@jest/types/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
+
+    "jest-watcher/string-length/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "lighthouse/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -4233,7 +4376,15 @@
 
     "markdownlint/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "nyc/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "nyc/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "nyc/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "renderkid/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
     "sane/execa/cross-spawn/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 
@@ -4252,6 +4403,10 @@
     "schema-utils/ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "unset-value/has-value/isobject/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "wait-port/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
+    "wait-port/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -4285,9 +4440,15 @@
 
     "jest-cli/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "jest-config/babel-jest/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "jest-snapshot/@jest/transform/babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "lighthouse/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "nyc/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "nyc/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
@@ -4298,6 +4459,8 @@
     "sane/micromatch/braces/fill-range/is-number": ["is-number@3.0.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg=="],
 
     "sane/micromatch/braces/fill-range/to-regex-range": ["to-regex-range@2.1.1", "", { "dependencies": { "is-number": "^3.0.0", "repeat-string": "^1.6.1" } }, "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg=="],
+
+    "wait-port/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "@lhci/cli/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,7 +10,9 @@ const config: Config = {
   // barrel and ambient declarations carry no testable logic.
   collectCoverageFrom: [
     '<rootDir>/src/**/*.{ts,tsx}',
-    '!<rootDir>/src/**/*.stories.{ts,tsx}',
+    // Mirrors the stories glob in .storybook/main.ts — every flavour Storybook
+    // loads must be excluded, or the first one added fails the 100% gate.
+    '!<rootDir>/src/**/*.stories.{js,jsx,mjs,ts,tsx}',
     '!<rootDir>/src/**/*.d.ts',
     '!<rootDir>/src/**/types.ts',
     '!<rootDir>/src/index.ts',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   // barrel and ambient declarations carry no testable logic.
   collectCoverageFrom: [
     '<rootDir>/src/**/*.{ts,tsx}',
-    '!<rootDir>/src/**/*.stories.tsx',
+    '!<rootDir>/src/**/*.stories.{ts,tsx}',
     '!<rootDir>/src/**/*.d.ts',
     '!<rootDir>/src/**/types.ts',
     '!<rootDir>/src/index.ts',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
     "@storybook/react": "^10.4.2",
     "@storybook/react-webpack5": "^10.4.2",
+    "@storybook/test-runner": "^0.24.4",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/jest-runner": "^9.6.1",
     "@stryker-mutator/typescript": "^4.0.0",

--- a/scripts/check-test-structure.sh
+++ b/scripts/check-test-structure.sh
@@ -56,7 +56,7 @@ if [ -n "$matches" ]; then
   printf '%s\n' "$matches" | sed 's,^\./,  ,' >&2
   echo >&2
   echo "Move them under tests/ (tests/unit, tests/integration, tests/e2e," >&2
-  echo "tests/visual, tests/load, tests/memory-leak, tests/bats)." >&2
+  echo "tests/visual, tests/storybook, tests/load, tests/memory-leak, tests/bats)." >&2
   exit 1
 fi
 

--- a/scripts/ci/run-storybook-interactions.ts
+++ b/scripts/ci/run-storybook-interactions.ts
@@ -19,7 +19,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import { readFileSync, realpathSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 
 import {
   MINIMUM_COMPONENTS,
@@ -40,6 +40,10 @@ const REPORT_NAME: string = 'interactions.xml';
 const OUTSIDE_ROOT: string =
   'refusing to read an interaction manifest from outside the project root';
 const UNREADABLE: string = 'the interaction manifest is missing or is not valid JSON';
+// A path escapes the root only when `..` is a whole leading SEGMENT — testing the
+// bare `..` prefix would also reject an in-root file or directory merely named
+// `..something`.
+const PARENT_SEGMENT: string = `..${sep}`;
 
 /** Aborts the gate; every failure funnels through `main`'s handler. */
 function fail(message: string): never {
@@ -61,7 +65,12 @@ function readManifest(candidate: string): InteractionStory[] {
   const resolved: string = resolve(PROJECT_ROOT, candidate);
   const relativeToRoot: string = relative(PROJECT_ROOT, resolved);
 
-  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
+  if (
+    relativeToRoot === '' ||
+    relativeToRoot === '..' ||
+    relativeToRoot.startsWith(PARENT_SEGMENT) ||
+    isAbsolute(relativeToRoot)
+  ) {
     return fail(OUTSIDE_ROOT);
   }
 
@@ -75,7 +84,12 @@ function readManifest(candidate: string): InteractionStory[] {
 
   const canonicalToRoot: string = relative(realpathSync(PROJECT_ROOT), canonical);
 
-  if (canonicalToRoot === '' || canonicalToRoot.startsWith('..') || isAbsolute(canonicalToRoot)) {
+  if (
+    canonicalToRoot === '' ||
+    canonicalToRoot === '..' ||
+    canonicalToRoot.startsWith(PARENT_SEGMENT) ||
+    isAbsolute(canonicalToRoot)
+  ) {
     return fail(OUTSIDE_ROOT);
   }
 
@@ -178,7 +192,7 @@ function runTestRunner(url: string): void {
   }
 }
 
-/** The play tests proven to have passed; every manifest row must be among them. */
+/** The DISTINCT play tests proven to have passed; every manifest row must be among them. */
 function assertEveryStoryRan(manifest: InteractionStory[]): string[] {
   const reportPath: string = resolve(PROJECT_ROOT, REPORT_DIR, REPORT_NAME);
   let report: string;
@@ -196,7 +210,10 @@ function assertEveryStoryRan(manifest: InteractionStory[]): string[] {
     fail(`the executed play tests do not match the manifest:\n${drift}`);
   }
 
-  return passed;
+  // `junitPlayTestKeys` returns report ROWS and the drift compare is set-based, so
+  // a report carrying the same case twice would pass while inflating the count.
+  // Collapse to distinct stories: the printed number is evidence, not a row tally.
+  return [...new Set(passed)];
 }
 
 async function main(): Promise<void> {

--- a/scripts/ci/run-storybook-interactions.ts
+++ b/scripts/ci/run-storybook-interactions.ts
@@ -13,12 +13,13 @@
  *     entry, with no failures, errors or skips among them.
  *
  * Usage: bun scripts/ci/run-storybook-interactions.ts [manifest-path]
- *   The Storybook URL comes from REACT_APP_STORYBOOK_URL (the `playwright` compose
+ *   The manifest path is optional and must stay inside the project root. The
+ *   Storybook URL comes from REACT_APP_STORYBOOK_URL (the `playwright` compose
  *   service sets it), falling back to http://127.0.0.1:6006.
  */
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 import {
   MINIMUM_COMPONENTS,
@@ -29,29 +30,57 @@ import {
   type InteractionStory,
 } from './storybook-interaction-manifest';
 
-const DEFAULT_MANIFEST = 'tests/storybook/interaction-stories.json';
-const DEFAULT_URL = 'http://127.0.0.1:6006';
-const REPORT_DIR = 'reports/storybook';
-const REPORT_NAME = 'interactions.xml';
+const PROJECT_ROOT: string = resolve(process.cwd());
+const DEFAULT_MANIFEST: string = 'tests/storybook/interaction-stories.json';
+const DEFAULT_URL: string = 'http://127.0.0.1:6006';
+const REPORT_DIR: string = 'reports/storybook';
+const REPORT_NAME: string = 'interactions.xml';
 
 function fail(message: string): never {
-  console.error(`storybook interaction gate: ${message}`);
+  process.stderr.write(`storybook interaction gate: ${message}\n`);
   process.exit(1);
+}
+
+/**
+ * Resolves the manifest argument against the project root and refuses anything
+ * that escapes it, so a caller-supplied path can never make this gate read (and
+ * then trust) a file from outside the repository.
+ */
+function resolveManifestPath(candidate: string): string {
+  const resolved: string = resolve(PROJECT_ROOT, candidate);
+  const relativeToRoot: string = relative(PROJECT_ROOT, resolved);
+
+  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
+    fail('refusing to read an interaction manifest from outside the project root');
+  }
+
+  return resolved;
 }
 
 function readManifest(path: string): InteractionStory[] {
   try {
     return JSON.parse(readFileSync(path, 'utf8')) as InteractionStory[];
-  } catch (error) {
-    return fail(`cannot read the interaction manifest at ${path}: ${String(error)}`);
+  } catch {
+    return fail('the interaction manifest is missing or is not valid JSON');
   }
 }
 
-async function fetchLiveStories(url: string): Promise<InteractionStory[]> {
-  const response = await fetch(`${url}/index.json`);
-  if (!response.ok) {
-    return fail(`GET ${url}/index.json returned ${response.status}`);
+/** Drops trailing slashes without a backtracking-prone regex. */
+function trimTrailingSlashes(url: string): string {
+  let end: number = url.length;
+  while (end > 0 && url.charAt(end - 1) === '/') {
+    end -= 1;
   }
+  return url.slice(0, end);
+}
+
+async function fetchLiveStories(url: string): Promise<InteractionStory[]> {
+  const response: Response = await fetch(`${url}/index.json`);
+
+  if (!response.ok) {
+    return fail(`the Storybook index request failed with status ${response.status}`);
+  }
+
   return liveInteractionStories(await response.json());
 }
 
@@ -69,14 +98,17 @@ function assertManifestMatchesIndex(manifest: InteractionStory[], live: Interact
     interactionStoryKeys(manifest),
     interactionStoryKeys(live)
   );
+
   if (drift) {
     fail(`the manifest and the live Storybook index disagree:\n${drift}`);
   }
 }
 
 function runTestRunner(url: string): void {
+  // `process.execPath` is the absolute path of the Bun binary already running this
+  // script, so the child is never resolved through PATH.
   const result = spawnSync(
-    'bun',
+    process.execPath,
     [
       'x',
       'test-storybook',
@@ -113,13 +145,13 @@ function runTestRunner(url: string): void {
 }
 
 function assertEveryStoryRan(manifest: InteractionStory[]): void {
-  const reportPath: string = resolve(REPORT_DIR, REPORT_NAME);
+  const reportPath: string = resolve(PROJECT_ROOT, REPORT_DIR, REPORT_NAME);
   let report: string;
 
   try {
     report = readFileSync(reportPath, 'utf8');
-  } catch (error) {
-    return fail(`no JUnit report at ${reportPath}: ${String(error)}`);
+  } catch {
+    return fail('the interaction suite produced no JUnit report');
   }
 
   const drift: string | null = formatDrift(
@@ -133,17 +165,17 @@ function assertEveryStoryRan(manifest: InteractionStory[]): void {
 }
 
 async function main(): Promise<void> {
-  const manifestPath: string = resolve(process.argv[2] ?? DEFAULT_MANIFEST);
-  const url: string = (process.env.REACT_APP_STORYBOOK_URL ?? DEFAULT_URL).replace(/\/+$/, '');
+  const manifestPath: string = resolveManifestPath(process.argv[2] ?? DEFAULT_MANIFEST);
+  const url: string = trimTrailingSlashes(process.env.REACT_APP_STORYBOOK_URL ?? DEFAULT_URL);
   const manifest: InteractionStory[] = readManifest(manifestPath);
 
   assertManifestMatchesIndex(manifest, await fetchLiveStories(url));
   runTestRunner(url);
   assertEveryStoryRan(manifest);
 
-  console.log(`storybook interaction gate: ${manifest.length} play tests passed.`);
+  process.stdout.write(`storybook interaction gate: ${manifest.length} play tests passed.\n`);
 }
 
 main().catch((error: unknown) => {
-  fail(error instanceof Error ? error.message : String(error));
+  fail(`the gate crashed: ${error instanceof Error ? error.message : 'unknown error'}`);
 });

--- a/scripts/ci/run-storybook-interactions.ts
+++ b/scripts/ci/run-storybook-interactions.ts
@@ -91,10 +91,14 @@ function assertManifestMatchesIndex(manifest: InteractionStory[], live: Interact
     fail(`only ${components.size} components carry interactions; at least ${MINIMUM_COMPONENTS}`);
   }
 
-  const drift: string | null = formatDrift(
-    interactionStoryKeys(manifest),
-    interactionStoryKeys(live)
-  );
+  // The drift comparison below is set-based, so a duplicated row would inflate the
+  // registry without demanding a second passing play test. Reject duplicates.
+  const keys: string[] = interactionStoryKeys(manifest);
+  if (new Set(keys).size !== keys.length) {
+    fail('the interaction manifest lists the same story more than once');
+  }
+
+  const drift: string | null = formatDrift(keys, interactionStoryKeys(live));
 
   if (drift) {
     fail(`the manifest and the live Storybook index disagree:\n${drift}`);

--- a/scripts/ci/run-storybook-interactions.ts
+++ b/scripts/ci/run-storybook-interactions.ts
@@ -18,15 +18,17 @@
  *   service sets it), falling back to http://127.0.0.1:6006.
  */
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { isAbsolute, relative, resolve } from 'node:path';
 
 import {
   MINIMUM_COMPONENTS,
+  duplicateKeys,
   formatDrift,
   interactionStoryKeys,
   junitPlayTestKeys,
   liveInteractionStories,
+  playTestKeys,
   type InteractionStory,
 } from './storybook-interaction-manifest';
 
@@ -35,6 +37,9 @@ const DEFAULT_MANIFEST: string = 'tests/storybook/interaction-stories.json';
 const DEFAULT_URL: string = 'http://127.0.0.1:6006';
 const REPORT_DIR: string = 'reports/storybook';
 const REPORT_NAME: string = 'interactions.xml';
+const OUTSIDE_ROOT: string =
+  'refusing to read an interaction manifest from outside the project root';
+const UNREADABLE: string = 'the interaction manifest is missing or is not valid JSON';
 
 /** Aborts the gate; every failure funnels through `main`'s handler. */
 function fail(message: string): never {
@@ -44,21 +49,40 @@ function fail(message: string): never {
 /**
  * Resolves the caller-supplied manifest path against the project root and refuses
  * anything that escapes it — the gate must never read (and then trust) a file from
- * outside the repository. The containment check sits in the same function as the
- * filesystem read so the sanitized path is the only one that can reach it.
+ * outside the repository. Containment is checked TWICE, both times in the same
+ * function as the filesystem read so the sanitized path is the only one that can
+ * reach it: lexically first, so no `fs` call ever sees an unvalidated path, then
+ * again on the `realpathSync` result, because a symlink that sits inside the
+ * repository can still target a file outside it and would pass a purely lexical
+ * test. The realpath/read window is deliberately left open — the threat model
+ * already assumes the checkout itself is untampered during a CI run.
  */
 function readManifest(candidate: string): InteractionStory[] {
   const resolved: string = resolve(PROJECT_ROOT, candidate);
   const relativeToRoot: string = relative(PROJECT_ROOT, resolved);
 
   if (relativeToRoot === '' || relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
-    throw new Error('refusing to read an interaction manifest from outside the project root');
+    return fail(OUTSIDE_ROOT);
+  }
+
+  let canonical: string;
+
+  try {
+    canonical = realpathSync(resolved);
+  } catch {
+    return fail(UNREADABLE);
+  }
+
+  const canonicalToRoot: string = relative(realpathSync(PROJECT_ROOT), canonical);
+
+  if (canonicalToRoot === '' || canonicalToRoot.startsWith('..') || isAbsolute(canonicalToRoot)) {
+    return fail(OUTSIDE_ROOT);
   }
 
   try {
-    return JSON.parse(readFileSync(resolved, 'utf8')) as InteractionStory[];
+    return JSON.parse(readFileSync(canonical, 'utf8')) as InteractionStory[];
   } catch {
-    return fail('the interaction manifest is missing or is not valid JSON');
+    return fail(UNREADABLE);
   }
 }
 
@@ -91,14 +115,23 @@ function assertManifestMatchesIndex(manifest: InteractionStory[], live: Interact
     fail(`only ${components.size} components carry interactions; at least ${MINIMUM_COMPONENTS}`);
   }
 
-  // The drift comparison below is set-based, so a duplicated row would inflate the
-  // registry without demanding a second passing play test. Reject duplicates.
-  const keys: string[] = interactionStoryKeys(manifest);
-  if (new Set(keys).size !== keys.length) {
-    fail('the interaction manifest lists the same story more than once');
+  // Both drift comparisons are set-based, so a row duplicated in EITHER key space
+  // would inflate the registry without demanding a second passing play test. The
+  // id space is what the live index is reconciled against; the title+exportName
+  // space is what the JUnit report is reconciled against, and two rows can collide
+  // there while carrying distinct ids. Reject duplicates in both.
+  const duplicates: string[] = [
+    ...duplicateKeys(interactionStoryKeys(manifest)),
+    ...duplicateKeys(playTestKeys(manifest)),
+  ];
+  if (duplicates.length > 0) {
+    fail(`the interaction manifest lists the same story more than once: ${duplicates.join(', ')}`);
   }
 
-  const drift: string | null = formatDrift(keys, interactionStoryKeys(live));
+  const drift: string | null = formatDrift(
+    interactionStoryKeys(manifest),
+    interactionStoryKeys(live)
+  );
 
   if (drift) {
     fail(`the manifest and the live Storybook index disagree:\n${drift}`);
@@ -145,7 +178,8 @@ function runTestRunner(url: string): void {
   }
 }
 
-function assertEveryStoryRan(manifest: InteractionStory[]): void {
+/** The play tests proven to have passed; every manifest row must be among them. */
+function assertEveryStoryRan(manifest: InteractionStory[]): string[] {
   const reportPath: string = resolve(PROJECT_ROOT, REPORT_DIR, REPORT_NAME);
   let report: string;
 
@@ -155,14 +189,14 @@ function assertEveryStoryRan(manifest: InteractionStory[]): void {
     return fail('the interaction suite produced no JUnit report');
   }
 
-  const drift: string | null = formatDrift(
-    manifest.map(story => `${story.title} ${story.exportName}`),
-    junitPlayTestKeys(report)
-  );
+  const passed: string[] = junitPlayTestKeys(report);
+  const drift: string | null = formatDrift(playTestKeys(manifest), passed);
 
   if (drift) {
     fail(`the executed play tests do not match the manifest:\n${drift}`);
   }
+
+  return passed;
 }
 
 async function main(): Promise<void> {
@@ -171,9 +205,10 @@ async function main(): Promise<void> {
 
   assertManifestMatchesIndex(manifest, await fetchLiveStories(url));
   runTestRunner(url);
-  assertEveryStoryRan(manifest);
+  // Report what was reconciled, not what was registered, so the count is evidence.
+  const passed: string[] = assertEveryStoryRan(manifest);
 
-  process.stdout.write(`storybook interaction gate: ${manifest.length} play tests passed.\n`);
+  process.stdout.write(`storybook interaction gate: ${passed.length} play tests passed.\n`);
 }
 
 main().catch((error: unknown) => {

--- a/scripts/ci/run-storybook-interactions.ts
+++ b/scripts/ci/run-storybook-interactions.ts
@@ -36,30 +36,27 @@ const DEFAULT_URL: string = 'http://127.0.0.1:6006';
 const REPORT_DIR: string = 'reports/storybook';
 const REPORT_NAME: string = 'interactions.xml';
 
+/** Aborts the gate; every failure funnels through `main`'s handler. */
 function fail(message: string): never {
-  process.stderr.write(`storybook interaction gate: ${message}\n`);
-  process.exit(1);
+  throw new Error(message);
 }
 
 /**
- * Resolves the manifest argument against the project root and refuses anything
- * that escapes it, so a caller-supplied path can never make this gate read (and
- * then trust) a file from outside the repository.
+ * Resolves the caller-supplied manifest path against the project root and refuses
+ * anything that escapes it — the gate must never read (and then trust) a file from
+ * outside the repository. The containment check sits in the same function as the
+ * filesystem read so the sanitized path is the only one that can reach it.
  */
-function resolveManifestPath(candidate: string): string {
+function readManifest(candidate: string): InteractionStory[] {
   const resolved: string = resolve(PROJECT_ROOT, candidate);
   const relativeToRoot: string = relative(PROJECT_ROOT, resolved);
 
   if (relativeToRoot === '' || relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
-    fail('refusing to read an interaction manifest from outside the project root');
+    throw new Error('refusing to read an interaction manifest from outside the project root');
   }
 
-  return resolved;
-}
-
-function readManifest(path: string): InteractionStory[] {
   try {
-    return JSON.parse(readFileSync(path, 'utf8')) as InteractionStory[];
+    return JSON.parse(readFileSync(resolved, 'utf8')) as InteractionStory[];
   } catch {
     return fail('the interaction manifest is missing or is not valid JSON');
   }
@@ -165,9 +162,8 @@ function assertEveryStoryRan(manifest: InteractionStory[]): void {
 }
 
 async function main(): Promise<void> {
-  const manifestPath: string = resolveManifestPath(process.argv[2] ?? DEFAULT_MANIFEST);
   const url: string = trimTrailingSlashes(process.env.REACT_APP_STORYBOOK_URL ?? DEFAULT_URL);
-  const manifest: InteractionStory[] = readManifest(manifestPath);
+  const manifest: InteractionStory[] = readManifest(process.argv[2] ?? DEFAULT_MANIFEST);
 
   assertManifestMatchesIndex(manifest, await fetchLiveStories(url));
   runTestRunner(url);
@@ -177,5 +173,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-  fail(`the gate crashed: ${error instanceof Error ? error.message : 'unknown error'}`);
+  const reason: string = error instanceof Error ? error.message : 'unknown error';
+  process.stderr.write(`storybook interaction gate: ${reason}\n`);
+  process.exit(1);
 });

--- a/scripts/ci/run-storybook-interactions.ts
+++ b/scripts/ci/run-storybook-interactions.ts
@@ -1,0 +1,149 @@
+/**
+ * Fail-closed entry point for the Storybook interaction (play function) suite.
+ *
+ * `@storybook/test-runner --includeTags interaction` turns every story file that
+ * carries no interaction story into `describe.skip(… no-op)`, so Jest happily
+ * exits 0 when the tag disappears from the whole library. That silent-skip hole is
+ * exactly what issue #100 forbids, so this wrapper brackets the run with two
+ * reconciliations against `tests/storybook/interaction-stories.json`:
+ *
+ *  1. BEFORE — the live Storybook index must expose exactly the manifest's
+ *     interaction-tagged stories, covering at least MINIMUM_COMPONENTS components.
+ *  2. AFTER  — the JUnit report must contain one PASSING `play-test` per manifest
+ *     entry, with no failures, errors or skips among them.
+ *
+ * Usage: bun scripts/ci/run-storybook-interactions.ts [manifest-path]
+ *   The Storybook URL comes from REACT_APP_STORYBOOK_URL (the `playwright` compose
+ *   service sets it), falling back to http://127.0.0.1:6006.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  MINIMUM_COMPONENTS,
+  formatDrift,
+  interactionStoryKeys,
+  junitPlayTestKeys,
+  liveInteractionStories,
+  type InteractionStory,
+} from './storybook-interaction-manifest';
+
+const DEFAULT_MANIFEST = 'tests/storybook/interaction-stories.json';
+const DEFAULT_URL = 'http://127.0.0.1:6006';
+const REPORT_DIR = 'reports/storybook';
+const REPORT_NAME = 'interactions.xml';
+
+function fail(message: string): never {
+  console.error(`storybook interaction gate: ${message}`);
+  process.exit(1);
+}
+
+function readManifest(path: string): InteractionStory[] {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as InteractionStory[];
+  } catch (error) {
+    return fail(`cannot read the interaction manifest at ${path}: ${String(error)}`);
+  }
+}
+
+async function fetchLiveStories(url: string): Promise<InteractionStory[]> {
+  const response = await fetch(`${url}/index.json`);
+  if (!response.ok) {
+    return fail(`GET ${url}/index.json returned ${response.status}`);
+  }
+  return liveInteractionStories(await response.json());
+}
+
+function assertManifestMatchesIndex(manifest: InteractionStory[], live: InteractionStory[]): void {
+  if (manifest.length === 0) {
+    fail('the interaction manifest is empty — interaction coverage may only grow.');
+  }
+
+  const components: Set<string> = new Set(manifest.map(story => story.title));
+  if (components.size < MINIMUM_COMPONENTS) {
+    fail(`only ${components.size} components carry interactions; at least ${MINIMUM_COMPONENTS}`);
+  }
+
+  const drift: string | null = formatDrift(
+    interactionStoryKeys(manifest),
+    interactionStoryKeys(live)
+  );
+  if (drift) {
+    fail(`the manifest and the live Storybook index disagree:\n${drift}`);
+  }
+}
+
+function runTestRunner(url: string): void {
+  const result = spawnSync(
+    'bun',
+    [
+      'x',
+      'test-storybook',
+      '--url',
+      url,
+      // CSF mode: index-json mode emits an EMPTY describe for every filtered-out
+      // story file, which Jest rejects as "must contain at least one test".
+      '--no-index-json',
+      '--includeTags',
+      'interaction',
+      '--browsers',
+      'chromium',
+      '--maxWorkers',
+      '2',
+      // A cold Storybook dev server compiles on the first navigation, so the
+      // default 15s per-test budget is too tight for the first few stories.
+      '--testTimeout',
+      '60000',
+      '--junit',
+    ],
+    {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        JEST_JUNIT_OUTPUT_DIR: REPORT_DIR,
+        JEST_JUNIT_OUTPUT_NAME: REPORT_NAME,
+      },
+    }
+  );
+
+  if (result.status !== 0) {
+    fail(`the interaction suite failed (test-storybook exited with ${String(result.status)})`);
+  }
+}
+
+function assertEveryStoryRan(manifest: InteractionStory[]): void {
+  const reportPath: string = resolve(REPORT_DIR, REPORT_NAME);
+  let report: string;
+
+  try {
+    report = readFileSync(reportPath, 'utf8');
+  } catch (error) {
+    return fail(`no JUnit report at ${reportPath}: ${String(error)}`);
+  }
+
+  const drift: string | null = formatDrift(
+    manifest.map(story => `${story.title} ${story.exportName}`),
+    junitPlayTestKeys(report)
+  );
+
+  if (drift) {
+    fail(`the executed play tests do not match the manifest:\n${drift}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const manifestPath: string = resolve(process.argv[2] ?? DEFAULT_MANIFEST);
+  const url: string = (process.env.REACT_APP_STORYBOOK_URL ?? DEFAULT_URL).replace(/\/+$/, '');
+  const manifest: InteractionStory[] = readManifest(manifestPath);
+
+  assertManifestMatchesIndex(manifest, await fetchLiveStories(url));
+  runTestRunner(url);
+  assertEveryStoryRan(manifest);
+
+  console.log(`storybook interaction gate: ${manifest.length} play tests passed.`);
+}
+
+main().catch((error: unknown) => {
+  fail(error instanceof Error ? error.message : String(error));
+});

--- a/scripts/ci/story-play-functions.ts
+++ b/scripts/ci/story-play-functions.ts
@@ -17,6 +17,32 @@ export interface ScannedStory {
   tags: string[];
 }
 
+// Mirrors the stories glob in `.storybook/main.ts` (`*.stories.@(js|jsx|mjs|ts|tsx)`).
+// Narrowing this to `.tsx` alone would let a CSF module in any other flavour carry a
+// `play` function that the drift guard never sees.
+const STORY_FILE = /\.stories\.(?:mjs|jsx?|tsx?)$/;
+
+/** `true` when `fileName` is a CSF story module in any flavour Storybook loads. */
+export function isStoryFile(fileName: string): boolean {
+  return STORY_FILE.test(fileName);
+}
+
+/**
+ * Parses a story module under the grammar its extension implies. Only a plain `.ts`
+ * module gets the non-JSX grammar: read with TSX rules it would mis-parse a bare
+ * generic (`<T>(v: T) => v`) as an unclosed JSX tag and swallow the rest of the
+ * file, hiding its stories. Every other flavour tolerates the JSX-capable variant.
+ */
+function parse(fileName: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    fileName.endsWith('.ts') ? ts.ScriptKind.TS : ts.ScriptKind.TSX
+  );
+}
+
 /** Strips the wrappers CSF authors put around a story object (`as`, `satisfies`). */
 function unwrap(expression: ts.Expression): ts.Expression {
   let current: ts.Expression = expression;
@@ -88,61 +114,52 @@ function scanStatement(statement: ts.Statement): ScannedStory[] {
 
 /** Every exported CSF story object in `source`, with its `play`/`tags` facts. */
 export function scanStories(fileName: string, source: string): ScannedStory[] {
-  const sourceFile: ts.SourceFile = ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  );
-
-  return sourceFile.statements.flatMap(scanStatement);
+  return parse(fileName, source).statements.flatMap(scanStatement);
 }
 
-function titleIn(literal: ts.ObjectLiteralExpression | null): string[] {
+function titleOf(literal: ts.ObjectLiteralExpression | null): string | null {
   const title: ts.ObjectLiteralElementLike | undefined = literal
     ? propertyNamed(literal, 'title')
     : undefined;
 
   if (!title || !ts.isPropertyAssignment(title) || !ts.isStringLiteralLike(title.initializer)) {
-    return [];
+    return null;
   }
 
-  return [title.initializer.text];
+  return title.initializer.text;
 }
 
-// `export default { title: … }` — the meta object is the default export itself.
-function defaultExportTitle(statement: ts.Statement): string[] {
-  return ts.isExportAssignment(statement) ? titleIn(objectLiteralOf(statement.expression)) : [];
+/** The initializer of the top-level `const <name> = …` declaration, if any. */
+function initializerOf(sourceFile: ts.SourceFile, name: string): ts.Expression | undefined {
+  return sourceFile.statements
+    .filter(ts.isVariableStatement)
+    .flatMap(statement => statement.declarationList.declarations)
+    .find(declaration => ts.isIdentifier(declaration.name) && declaration.name.text === name)
+    ?.initializer;
 }
 
-// `const meta = { title: … }; export default meta;` — the common CSF shape. Any
-// declared object carrying a string `title` is a meta candidate; the unit guard
-// asserts every story file yields exactly one, so an ambiguous file fails loudly.
-function declaredTitle(statement: ts.Statement): string[] {
-  if (!ts.isVariableStatement(statement)) {
-    return [];
-  }
-
-  return statement.declarationList.declarations.flatMap(declaration =>
-    titleIn(objectLiteralOf(declaration.initializer))
+/**
+ * The object Storybook receives as the module's default export — either written
+ * inline (`export default { title: … }`) or named (`const meta = …; export
+ * default meta;`). A named export is resolved back to ITS declaration: reading
+ * the first titled object in the file instead would let an unrelated helper
+ * object declared above `meta` supply the wrong title.
+ */
+function defaultExport(sourceFile: ts.SourceFile): ts.Expression | undefined {
+  const assignment: ts.ExportAssignment | undefined = sourceFile.statements.find(
+    ts.isExportAssignment
   );
+
+  if (!assignment) {
+    return undefined;
+  }
+
+  const exported: ts.Expression = unwrap(assignment.expression);
+
+  return ts.isIdentifier(exported) ? initializerOf(sourceFile, exported.text) : exported;
 }
 
 /** The `title` of the CSF meta object (the default export), or `null` when absent. */
 export function scanMetaTitle(fileName: string, source: string): string | null {
-  const sourceFile: ts.SourceFile = ts.createSourceFile(
-    fileName,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  );
-  const exported: string[] = sourceFile.statements.flatMap(defaultExportTitle);
-
-  if (exported.length > 0) {
-    return exported[0];
-  }
-
-  return sourceFile.statements.flatMap(declaredTitle)[0] ?? null;
+  return titleOf(objectLiteralOf(defaultExport(parse(fileName, source))));
 }

--- a/scripts/ci/story-play-functions.ts
+++ b/scripts/ci/story-play-functions.ts
@@ -17,9 +17,30 @@ export interface ScannedStory {
   tags: string[];
 }
 
-function objectLiteralOf(declaration: ts.VariableDeclaration): ts.ObjectLiteralExpression | null {
-  const initializer: ts.Expression | undefined = declaration.initializer;
-  return initializer && ts.isObjectLiteralExpression(initializer) ? initializer : null;
+/** Strips the wrappers CSF authors put around a story object (`as`, `satisfies`). */
+function unwrap(expression: ts.Expression): ts.Expression {
+  let current: ts.Expression = expression;
+
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isParenthesizedExpression(current)
+  ) {
+    current = current.expression;
+  }
+
+  return current;
+}
+
+function objectLiteralOf(
+  initializer: ts.Expression | undefined
+): ts.ObjectLiteralExpression | null {
+  if (!initializer) {
+    return null;
+  }
+  const unwrapped: ts.Expression = unwrap(initializer);
+
+  return ts.isObjectLiteralExpression(unwrapped) ? unwrapped : null;
 }
 
 function propertyNamed(
@@ -51,7 +72,7 @@ function scanStatement(statement: ts.Statement): ScannedStory[] {
   }
 
   return statement.declarationList.declarations.flatMap(declaration => {
-    const literal: ts.ObjectLiteralExpression | null = objectLiteralOf(declaration);
+    const literal: ts.ObjectLiteralExpression | null = objectLiteralOf(declaration.initializer);
     if (!literal || !ts.isIdentifier(declaration.name)) {
       return [];
     }
@@ -78,22 +99,34 @@ export function scanStories(fileName: string, source: string): ScannedStory[] {
   return sourceFile.statements.flatMap(scanStatement);
 }
 
-function titleOf(statement: ts.Statement): string[] {
+function titleIn(literal: ts.ObjectLiteralExpression | null): string[] {
+  const title: ts.ObjectLiteralElementLike | undefined = literal
+    ? propertyNamed(literal, 'title')
+    : undefined;
+
+  if (!title || !ts.isPropertyAssignment(title) || !ts.isStringLiteralLike(title.initializer)) {
+    return [];
+  }
+
+  return [title.initializer.text];
+}
+
+// `export default { title: … }` — the meta object is the default export itself.
+function defaultExportTitle(statement: ts.Statement): string[] {
+  return ts.isExportAssignment(statement) ? titleIn(objectLiteralOf(statement.expression)) : [];
+}
+
+// `const meta = { title: … }; export default meta;` — the common CSF shape. Any
+// declared object carrying a string `title` is a meta candidate; the unit guard
+// asserts every story file yields exactly one, so an ambiguous file fails loudly.
+function declaredTitle(statement: ts.Statement): string[] {
   if (!ts.isVariableStatement(statement)) {
     return [];
   }
 
-  return statement.declarationList.declarations.flatMap(declaration => {
-    const literal: ts.ObjectLiteralExpression | null = objectLiteralOf(declaration);
-    const title: ts.ObjectLiteralElementLike | undefined = literal
-      ? propertyNamed(literal, 'title')
-      : undefined;
-
-    if (!title || !ts.isPropertyAssignment(title) || !ts.isStringLiteralLike(title.initializer)) {
-      return [];
-    }
-    return [title.initializer.text];
-  });
+  return statement.declarationList.declarations.flatMap(declaration =>
+    titleIn(objectLiteralOf(declaration.initializer))
+  );
 }
 
 /** The `title` of the CSF meta object (the default export), or `null` when absent. */
@@ -105,6 +138,11 @@ export function scanMetaTitle(fileName: string, source: string): string | null {
     true,
     ts.ScriptKind.TSX
   );
+  const exported: string[] = sourceFile.statements.flatMap(defaultExportTitle);
 
-  return sourceFile.statements.flatMap(titleOf)[0] ?? null;
+  if (exported.length > 0) {
+    return exported[0];
+  }
+
+  return sourceFile.statements.flatMap(declaredTitle)[0] ?? null;
 }

--- a/scripts/ci/story-play-functions.ts
+++ b/scripts/ci/story-play-functions.ts
@@ -139,11 +139,29 @@ function initializerOf(sourceFile: ts.SourceFile, name: string): ts.Expression |
 }
 
 /**
- * The object Storybook receives as the module's default export — either written
- * inline (`export default { title: … }`) or named (`const meta = …; export
- * default meta;`). A named export is resolved back to ITS declaration: reading
- * the first titled object in the file instead would let an unrelated helper
- * object declared above `meta` supply the wrong title.
+ * The local name a `export { meta as default }` clause aliases, if the module uses
+ * that form instead of `export default`. Re-exports (`export { x as default } from
+ * './y'`) carry a module specifier and are skipped: their declaration is in another
+ * file, so there is nothing to resolve here.
+ */
+function defaultAlias(sourceFile: ts.SourceFile): string | undefined {
+  return sourceFile.statements
+    .filter(ts.isExportDeclaration)
+    .filter(declaration => declaration.moduleSpecifier === undefined)
+    .flatMap(declaration =>
+      declaration.exportClause && ts.isNamedExports(declaration.exportClause)
+        ? [...declaration.exportClause.elements]
+        : []
+    )
+    .find(element => element.name.text === 'default')?.propertyName?.text;
+}
+
+/**
+ * The object Storybook receives as the module's default export, written inline
+ * (`export default { title: … }`), named (`const meta = …; export default meta;`)
+ * or aliased (`export { meta as default };`). A name is resolved back to ITS
+ * declaration: reading the first titled object in the file instead would let an
+ * unrelated helper object declared above `meta` supply the wrong title.
  */
 function defaultExport(sourceFile: ts.SourceFile): ts.Expression | undefined {
   const assignment: ts.ExportAssignment | undefined = sourceFile.statements.find(
@@ -151,7 +169,9 @@ function defaultExport(sourceFile: ts.SourceFile): ts.Expression | undefined {
   );
 
   if (!assignment) {
-    return undefined;
+    const alias: string | undefined = defaultAlias(sourceFile);
+
+    return alias === undefined ? undefined : initializerOf(sourceFile, alias);
   }
 
   const exported: ts.Expression = unwrap(assignment.expression);

--- a/scripts/ci/story-play-functions.ts
+++ b/scripts/ci/story-play-functions.ts
@@ -1,0 +1,110 @@
+/**
+ * Static scan of a CSF story module for `play` functions and story tags.
+ *
+ * Used by the unit-tier drift guard so a `play` function can never be added to a
+ * story without being tagged `interaction` and registered in
+ * `tests/storybook/interaction-stories.json`. The scan is deliberately static
+ * (TypeScript AST, no module evaluation): importing story modules would drag the
+ * whole component tree into the Jest run and make Stryker re-run this guard for
+ * every mutant.
+ */
+import ts from 'typescript';
+
+/** One exported story and the two facts the interaction gate cares about. */
+export interface ScannedStory {
+  exportName: string;
+  hasPlay: boolean;
+  tags: string[];
+}
+
+function objectLiteralOf(declaration: ts.VariableDeclaration): ts.ObjectLiteralExpression | null {
+  const initializer: ts.Expression | undefined = declaration.initializer;
+  return initializer && ts.isObjectLiteralExpression(initializer) ? initializer : null;
+}
+
+function propertyNamed(
+  literal: ts.ObjectLiteralExpression,
+  name: string
+): ts.ObjectLiteralElementLike | undefined {
+  return literal.properties.find(property => property.name?.getText() === name);
+}
+
+function stringLiteralsOf(property: ts.ObjectLiteralElementLike | undefined): string[] {
+  if (!property || !ts.isPropertyAssignment(property)) {
+    return [];
+  }
+  if (!ts.isArrayLiteralExpression(property.initializer)) {
+    return [];
+  }
+  return property.initializer.elements.filter(ts.isStringLiteralLike).map(element => element.text);
+}
+
+function isExported(statement: ts.VariableStatement): boolean {
+  return (
+    statement.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword) === true
+  );
+}
+
+function scanStatement(statement: ts.Statement): ScannedStory[] {
+  if (!ts.isVariableStatement(statement) || !isExported(statement)) {
+    return [];
+  }
+
+  return statement.declarationList.declarations.flatMap(declaration => {
+    const literal: ts.ObjectLiteralExpression | null = objectLiteralOf(declaration);
+    if (!literal || !ts.isIdentifier(declaration.name)) {
+      return [];
+    }
+    return [
+      {
+        exportName: declaration.name.text,
+        hasPlay: propertyNamed(literal, 'play') !== undefined,
+        tags: stringLiteralsOf(propertyNamed(literal, 'tags')),
+      },
+    ];
+  });
+}
+
+/** Every exported CSF story object in `source`, with its `play`/`tags` facts. */
+export function scanStories(fileName: string, source: string): ScannedStory[] {
+  const sourceFile: ts.SourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+
+  return sourceFile.statements.flatMap(scanStatement);
+}
+
+function titleOf(statement: ts.Statement): string[] {
+  if (!ts.isVariableStatement(statement)) {
+    return [];
+  }
+
+  return statement.declarationList.declarations.flatMap(declaration => {
+    const literal: ts.ObjectLiteralExpression | null = objectLiteralOf(declaration);
+    const title: ts.ObjectLiteralElementLike | undefined = literal
+      ? propertyNamed(literal, 'title')
+      : undefined;
+
+    if (!title || !ts.isPropertyAssignment(title) || !ts.isStringLiteralLike(title.initializer)) {
+      return [];
+    }
+    return [title.initializer.text];
+  });
+}
+
+/** The `title` of the CSF meta object (the default export), or `null` when absent. */
+export function scanMetaTitle(fileName: string, source: string): string | null {
+  const sourceFile: ts.SourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+
+  return sourceFile.statements.flatMap(titleOf)[0] ?? null;
+}

--- a/scripts/ci/storybook-interaction-manifest.ts
+++ b/scripts/ci/storybook-interaction-manifest.ts
@@ -62,6 +62,34 @@ export function interactionStoryKeys(stories: InteractionStory[]): string[] {
   return stories.map(story => `${story.id} (${story.title} / ${story.exportName})`);
 }
 
+/** The JUnit test names the runner emits for a set of interaction stories. */
+export function playTestKeys(stories: InteractionStory[]): string[] {
+  return stories.map(story => `${story.title} ${story.exportName}`);
+}
+
+/**
+ * Every key that `keys` lists more than once, sorted.
+ *
+ * {@link formatDrift} compares SETS, so a key that appears twice on the expected
+ * side is satisfied by a single occurrence on the actual side. Both of the gate's
+ * key spaces must therefore be checked for duplicates before they are compared,
+ * or a duplicated registry row would stop demanding its own passing play test.
+ */
+export function duplicateKeys(keys: string[]): string[] {
+  const seen: Set<string> = new Set();
+  const duplicates: Set<string> = new Set();
+
+  keys.forEach(key => {
+    if (seen.has(key)) {
+      duplicates.add(key);
+      return;
+    }
+    seen.add(key);
+  });
+
+  return [...duplicates].sort((a, b) => a.localeCompare(b));
+}
+
 const TEST_CASE = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
 const CASE_NAME = /\bname="([^"]*)"/;
 const NOT_PASSED = /<(?:failure|error|skipped)\b/;

--- a/scripts/ci/storybook-interaction-manifest.ts
+++ b/scripts/ci/storybook-interaction-manifest.ts
@@ -65,7 +65,7 @@ export function interactionStoryKeys(stories: InteractionStory[]): string[] {
 const TEST_CASE = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
 const CASE_NAME = /\bname="([^"]*)"/;
 const NOT_PASSED = /<(?:failure|error|skipped)\b/;
-const PLAY_TEST_SUFFIX = / play-test$/;
+const PLAY_TEST_SUFFIX: string = ' play-test';
 
 /**
  * Names of the play tests that actually PASSED, read from a jest-junit report.
@@ -76,8 +76,8 @@ const PLAY_TEST_SUFFIX = / play-test$/;
 export function junitPlayTestKeys(report: string): string[] {
   return [...report.matchAll(TEST_CASE)]
     .map(match => ({ name: CASE_NAME.exec(match[1])?.[1] ?? '', body: match[2] ?? '' }))
-    .filter(entry => PLAY_TEST_SUFFIX.test(entry.name) && !NOT_PASSED.test(entry.body))
-    .map(entry => entry.name.replace(PLAY_TEST_SUFFIX, ''))
+    .filter(entry => entry.name.endsWith(PLAY_TEST_SUFFIX) && !NOT_PASSED.test(entry.body))
+    .map(entry => entry.name.slice(0, -PLAY_TEST_SUFFIX.length))
     .sort((a, b) => a.localeCompare(b));
 }
 
@@ -88,8 +88,9 @@ export function junitPlayTestKeys(report: string): string[] {
 export function formatDrift(expected: string[], actual: string[]): string | null {
   const expectedSet: Set<string> = new Set(expected);
   const actualSet: Set<string> = new Set(actual);
-  const missing: string[] = expected.filter(key => !actualSet.has(key)).sort();
-  const unexpected: string[] = actual.filter(key => !expectedSet.has(key)).sort();
+  const byName = (a: string, b: string): number => a.localeCompare(b);
+  const missing: string[] = expected.filter(key => !actualSet.has(key)).sort(byName);
+  const unexpected: string[] = actual.filter(key => !expectedSet.has(key)).sort(byName);
 
   if (missing.length === 0 && unexpected.length === 0) {
     return null;

--- a/scripts/ci/storybook-interaction-manifest.ts
+++ b/scripts/ci/storybook-interaction-manifest.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure helpers shared by the Storybook interaction gate
+ * ({@link ./run-storybook-interactions.ts}) and its unit tests.
+ *
+ * The manifest at `tests/storybook/interaction-stories.json` is the registry of
+ * stories that MUST carry a `play` function. Keeping the comparison logic pure
+ * here lets the unit tier assert the gate's behaviour without booting Storybook.
+ */
+
+/** Registry row: one story that must carry a `play` function. */
+export interface InteractionStory {
+  /** Storybook story id, e.g. `uicomponents-uibutton--click-invokes-handler`. */
+  id: string;
+  /** Component title, e.g. `UiComponents/UiButton`. */
+  title: string;
+  /** Display name, e.g. `Click Invokes Handler`. */
+  name: string;
+  /** CSF export, e.g. `ClickInvokesHandler` — how the JUnit report names the test. */
+  exportName: string;
+}
+
+/** The Storybook tag that routes a story into the interaction suite. */
+export const INTERACTION_TAG: string = 'interaction';
+
+/**
+ * Coverage floor from issue #100 ("≥ 8 interactive components have play
+ * functions"). It is a floor, never a target: raise it, never lower it.
+ */
+export const MINIMUM_COMPONENTS: number = 8;
+
+interface RawIndexEntry {
+  type?: string;
+  id?: string;
+  title?: string;
+  name?: string;
+  exportName?: string;
+  tags?: string[];
+}
+
+function isInteractionEntry(entry: RawIndexEntry): boolean {
+  return entry.type === 'story' && (entry.tags ?? []).includes(INTERACTION_TAG);
+}
+
+/** Extracts the interaction-tagged stories from a live Storybook `index.json`. */
+export function liveInteractionStories(index: unknown): InteractionStory[] {
+  const entries: Record<string, RawIndexEntry> =
+    (index as { entries?: Record<string, RawIndexEntry> })?.entries ?? {};
+
+  return Object.values(entries)
+    .filter(isInteractionEntry)
+    .map(entry => ({
+      id: entry.id ?? '',
+      title: entry.title ?? '',
+      name: entry.name ?? '',
+      exportName: entry.exportName ?? '',
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Stable comparison keys for a set of interaction stories. */
+export function interactionStoryKeys(stories: InteractionStory[]): string[] {
+  return stories.map(story => `${story.id} (${story.title} / ${story.exportName})`);
+}
+
+const TEST_CASE = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
+const CASE_NAME = /\bname="([^"]*)"/;
+const NOT_PASSED = /<(?:failure|error|skipped)\b/;
+const PLAY_TEST_SUFFIX = / play-test$/;
+
+/**
+ * Names of the play tests that actually PASSED, read from a jest-junit report.
+ * A skipped or failed case carries a `<skipped/>` / `<failure>` / `<error>` child,
+ * so only `play-test` cases with an empty body count as executed proof — that is
+ * what makes a silently-skipped interaction suite fail the gate.
+ */
+export function junitPlayTestKeys(report: string): string[] {
+  return [...report.matchAll(TEST_CASE)]
+    .map(match => ({ name: CASE_NAME.exec(match[1])?.[1] ?? '', body: match[2] ?? '' }))
+    .filter(entry => PLAY_TEST_SUFFIX.test(entry.name) && !NOT_PASSED.test(entry.body))
+    .map(entry => entry.name.replace(PLAY_TEST_SUFFIX, ''))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Compares two key sets, returning a human-readable drift report or `null` when
+ * they are identical.
+ */
+export function formatDrift(expected: string[], actual: string[]): string | null {
+  const expectedSet: Set<string> = new Set(expected);
+  const actualSet: Set<string> = new Set(actual);
+  const missing: string[] = expected.filter(key => !actualSet.has(key)).sort();
+  const unexpected: string[] = actual.filter(key => !expectedSet.has(key)).sort();
+
+  if (missing.length === 0 && unexpected.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [];
+  missing.forEach(key => lines.push(`  - missing: ${key}`));
+  unexpected.forEach(key => lines.push(`  - unregistered: ${key}`));
+
+  return lines.join('\n');
+}

--- a/scripts/ci/storybook-interaction-manifest.ts
+++ b/scripts/ci/storybook-interaction-manifest.ts
@@ -65,7 +65,21 @@ export function interactionStoryKeys(stories: InteractionStory[]): string[] {
 const TEST_CASE = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
 const CASE_NAME = /\bname="([^"]*)"/;
 const NOT_PASSED = /<(?:failure|error|skipped)\b/;
+const XML_ENTITY = /&(?:amp|lt|gt|quot|apos|#39);/g;
+const XML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+  '&#39;': "'",
+};
 const PLAY_TEST_SUFFIX: string = ' play-test';
+
+/** Reverses the escaping jest-junit applies to attribute values. */
+function decodeXml(value: string): string {
+  return value.replace(XML_ENTITY, entity => XML_ENTITIES[entity] ?? entity);
+}
 
 /**
  * Names of the play tests that actually PASSED, read from a jest-junit report.
@@ -75,7 +89,7 @@ const PLAY_TEST_SUFFIX: string = ' play-test';
  */
 export function junitPlayTestKeys(report: string): string[] {
   return [...report.matchAll(TEST_CASE)]
-    .map(match => ({ name: CASE_NAME.exec(match[1])?.[1] ?? '', body: match[2] ?? '' }))
+    .map(match => ({ name: decodeXml(CASE_NAME.exec(match[1])?.[1] ?? ''), body: match[2] ?? '' }))
     .filter(entry => entry.name.endsWith(PLAY_TEST_SUFFIX) && !NOT_PASSED.test(entry.body))
     .map(entry => entry.name.slice(0, -PLAY_TEST_SUFFIX.length))
     .sort((a, b) => a.localeCompare(b));

--- a/src/components/ui-back-to-main/back-to-main.stories.tsx
+++ b/src/components/ui-back-to-main/back-to-main.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import UiBackToMain from './index';
+
+const backLabel: string = 'Back to main';
+const backDestination: string = '/dashboard';
 
 const meta: Meta<typeof UiBackToMain> = {
   title: 'UiComponents/UiBackToMain',
@@ -26,4 +30,19 @@ export const CustomDestination: Story = {
 
 export const CustomLabel: Story = {
   args: { to: '/', label: 'Return home' },
+};
+
+// Interaction story (`interaction` tag): proves the back affordance is a keyboard
+// reachable link pointing at `to`. See tests/storybook/README.md.
+export const KeyboardFocusReachesBackLink: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: { to: backDestination, label: backLabel },
+  play: async ({ canvasElement }): Promise<void> => {
+    const link: HTMLElement = within(canvasElement).getByRole('link', { name: backLabel });
+
+    await userEvent.tab();
+
+    await expect(link).toHaveFocus();
+    await expect(link).toHaveAttribute('href', backDestination);
+  },
 };

--- a/src/components/ui-button/button.stories.tsx
+++ b/src/components/ui-button/button.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import UiButton from './index';
+
+const clickableLabel: string = t('header.actions.try_it_out');
 
 const meta: Meta<typeof UiButton> = {
   title: 'UiComponents/UiButton',
@@ -64,5 +67,26 @@ export const SocialButton: Story = {
     variant: 'outlined',
     size: 'medium',
     name: 'socialButton',
+  },
+};
+
+// Interaction story (`interaction` tag): proves the demoed button actually
+// dispatches `onClick` in a real browser. See tests/storybook/README.md.
+export const ClickInvokesHandler: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: {
+    children: clickableLabel,
+    variant: 'contained',
+    size: 'small',
+    onClick: fn(),
+  },
+  play: async ({ args, canvasElement }): Promise<void> => {
+    const button: HTMLElement = within(canvasElement).getByRole('button', {
+      name: clickableLabel,
+    });
+
+    await userEvent.click(button);
+
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
   },
 };

--- a/src/components/ui-calendar-multi-select/calendar-multi-select.stories.tsx
+++ b/src/components/ui-calendar-multi-select/calendar-multi-select.stories.tsx
@@ -1,7 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import React from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import UiCalendarMultiSelect from './index';
+
+const calendarLabel: string = t('Available dates');
+const pinnedMonth: string = '2025-09-15';
+// Accessible name of the day cell, built by `formatDayLabel` (`D Month YYYY`).
+const toggledDayName: string = '10 September 2025';
+
+// The calendar is fully controlled, so the interaction story owns the selection and
+// starts from an empty one.
+function CalendarInteractionStory(): React.ReactElement {
+  const [value, setValue] = React.useState<string[]>([]);
+
+  return (
+    <UiCalendarMultiSelect
+      label={calendarLabel}
+      defaultMonth={pinnedMonth}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
 
 const meta: Meta<typeof UiCalendarMultiSelect> = {
   title: 'UiComponents/UiCalendarMultiSelect',
@@ -35,10 +57,29 @@ type Story = StoryObj<typeof UiCalendarMultiSelect>;
 // marker would otherwise move day to day).
 export const CalendarMultiSelect: Story = {
   args: {
-    label: t('Available dates'),
-    defaultMonth: '2025-09-15',
+    label: calendarLabel,
+    defaultMonth: pinnedMonth,
     value: ['2025-09-05', '2025-09-12', '2025-09-20'],
     error: false,
     disabled: false,
+  },
+};
+
+// Interaction story (`interaction` tag): proves a day cell toggles on and back off,
+// reporting the state through `aria-selected`. See tests/storybook/README.md.
+export const DayToggleUpdatesSelection: Story = {
+  tags: ['interaction', '!autodocs'],
+  render: CalendarInteractionStory,
+  play: async ({ canvasElement }): Promise<void> => {
+    const day: HTMLElement = within(canvasElement).getByRole('gridcell', {
+      name: toggledDayName,
+    });
+
+    await userEvent.click(day);
+    await expect(day).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.click(day);
+
+    await expect(day).toHaveAttribute('aria-selected', 'false');
   },
 };

--- a/src/components/ui-checkbox/checkbox.stories.tsx
+++ b/src/components/ui-checkbox/checkbox.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import UiCheckbox from './index';
+
+const toggleLabel: string = t('Send me product updates');
 
 const meta: Meta<typeof UiCheckbox> = {
   title: 'UiComponents/UiCheckbox',
@@ -47,5 +50,26 @@ export const Checkbox: Story = {
   args: {
     error: false,
     label: t('Checkbox label text'),
+  },
+};
+
+// Interaction story (`interaction` tag): proves a click flips the checked state
+// and reports it through `onChange`. See tests/storybook/README.md.
+export const ClickTogglesCheckedState: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: {
+    error: false,
+    label: toggleLabel,
+    onChange: fn(),
+  },
+  play: async ({ args, canvasElement }): Promise<void> => {
+    const box: HTMLElement = within(canvasElement).getByRole('checkbox', { name: toggleLabel });
+
+    await expect(box).not.toBeChecked();
+
+    await userEvent.click(box);
+
+    await expect(box).toBeChecked();
+    await expect(args.onChange).toHaveBeenCalledTimes(1);
   },
 };

--- a/src/components/ui-form/form.stories.tsx
+++ b/src/components/ui-form/form.stories.tsx
@@ -1,12 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, type SubmitHandler } from 'react-hook-form';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import UiTextFieldForm from '../ui-text-field-form';
 
 import UiForm from './index';
 
 type DemoValues = { email: string };
+
+const emailLabel: string = 'Email';
+const submitLabel: string = 'Sign in';
+const requiredMessage: string = 'Email is required';
+const validEmail: string = 'ada@vilnacrm.com';
+const submitSpy: ReturnType<typeof fn> = fn();
+
+function ignoreSubmit(): void {}
 
 const meta: Meta<typeof UiForm> = {
   title: 'UiComponents/UiForm',
@@ -25,9 +34,9 @@ function DemoFields(): React.ReactElement {
     <UiTextFieldForm<DemoValues>
       control={control}
       name="email"
-      label="Email"
+      label={emailLabel}
       type="email"
-      rules={{ required: 'Email is required' }}
+      rules={{ required: requiredMessage }}
     />
   );
 }
@@ -36,16 +45,18 @@ function DemoForm({
   error,
   isSubmitting,
   isSubmitDisabled,
+  onSubmit = ignoreSubmit,
 }: {
   error?: string | null;
   isSubmitting?: boolean;
   isSubmitDisabled?: boolean;
+  onSubmit?: SubmitHandler<DemoValues>;
 }): React.ReactElement {
   return (
     <UiForm<DemoValues>
-      onSubmit={(): void => {}}
+      onSubmit={onSubmit}
       defaultValues={{ email: '' }}
-      submitLabel="Sign in"
+      submitLabel={submitLabel}
       title="Account access"
       error={error}
       isSubmitting={isSubmitting}
@@ -54,6 +65,10 @@ function DemoForm({
       <DemoFields />
     </UiForm>
   );
+}
+
+function SpyingDemoForm(): React.ReactElement {
+  return <DemoForm onSubmit={submitSpy} />;
 }
 
 export const Default: Story = {
@@ -70,4 +85,26 @@ export const Submitting: Story = {
 
 export const SubmitDisabled: Story = {
   render: (): React.ReactElement => <DemoForm isSubmitDisabled />,
+};
+
+// Interaction story (`interaction` tag): proves the form blocks an empty submit
+// with a visible field error and only calls `onSubmit` once the value is valid.
+// See tests/storybook/README.md.
+export const ValidationBlocksEmptySubmit: Story = {
+  tags: ['interaction', '!autodocs'],
+  render: SpyingDemoForm,
+  play: async ({ canvasElement }): Promise<void> => {
+    const canvas: ReturnType<typeof within> = within(canvasElement);
+    submitSpy.mockClear();
+
+    await userEvent.click(canvas.getByRole('button', { name: submitLabel }));
+
+    await expect(await canvas.findByText(requiredMessage)).toBeVisible();
+    await expect(submitSpy).not.toHaveBeenCalled();
+
+    await userEvent.type(canvas.getByRole('textbox', { name: emailLabel }), validEmail);
+    await userEvent.click(canvas.getByRole('button', { name: submitLabel }));
+
+    await waitFor((): Promise<void> => expect(submitSpy).toHaveBeenCalledTimes(1));
+  },
 };

--- a/src/components/ui-form/form.stories.tsx
+++ b/src/components/ui-form/form.stories.tsx
@@ -15,7 +15,10 @@ const requiredMessage: string = 'Email is required';
 const validEmail: string = 'ada@vilnacrm.com';
 const submitSpy: ReturnType<typeof fn> = fn();
 
-function ignoreSubmit(): void {}
+function ignoreSubmit(): void {
+  // The demo form has no backend; the presentational stories only need a valid
+  // submit handler, and the interaction story swaps in a spy.
+}
 
 const meta: Meta<typeof UiForm> = {
   title: 'UiComponents/UiForm',

--- a/src/components/ui-input/input.stories.tsx
+++ b/src/components/ui-input/input.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import UiInput from './index';
+
+const typedFieldLabel: string = t('Full name');
+const typedText: string = 'Ada Lovelace';
 
 const meta: Meta<typeof UiInput> = {
   title: 'UiComponents/UiInput',
@@ -45,5 +49,28 @@ export const Input: Story = {
   args: {
     placeholder: t('Input'),
     error: false,
+  },
+};
+
+// Interaction story (`interaction` tag): proves typing reaches the underlying
+// input, updates its value and reports every keystroke through `onChange`.
+// `onChange` is an explicit `fn()` spy — an implicit action arg throws when it is
+// invoked from a play function. See tests/storybook/README.md.
+export const TypingUpdatesValue: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: {
+    label: typedFieldLabel,
+    error: false,
+    onChange: fn(),
+  },
+  play: async ({ args, canvasElement }): Promise<void> => {
+    const field: HTMLElement = within(canvasElement).getByRole('textbox', {
+      name: typedFieldLabel,
+    });
+
+    await userEvent.type(field, typedText);
+
+    await expect(field).toHaveValue(typedText);
+    await expect(args.onChange).toHaveBeenCalledTimes(typedText.length);
   },
 };

--- a/src/components/ui-link/link.stories.tsx
+++ b/src/components/ui-link/link.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import { expect, userEvent, within } from 'storybook/test';
 
 import UiLink from './index';
+
+const externalLinkText: string = t('Read the docs');
+const newTabHint: string = '(opens in new tab)';
 
 const meta: Meta<typeof UiLink> = {
   title: 'UiComponents/UiLink',
@@ -27,5 +31,27 @@ export const Link: Story = {
   args: {
     children: t('Link'),
     href: '/',
+  },
+};
+
+// Interaction story (`interaction` tag): proves the link is keyboard reachable and
+// that a `target="_blank"` link folds the new-tab hint into its accessible name
+// while forcing `rel="noopener noreferrer"`. See tests/storybook/README.md.
+export const KeyboardFocusExposesNewTabHint: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: {
+    children: externalLinkText,
+    href: 'https://vilnacrm.com',
+    target: '_blank',
+  },
+  play: async ({ canvasElement }): Promise<void> => {
+    const link: HTMLElement = within(canvasElement).getByRole('link', {
+      name: `${externalLinkText} ${newTabHint}`,
+    });
+
+    await userEvent.tab();
+
+    await expect(link).toHaveFocus();
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   },
 };

--- a/src/components/ui-multi-select/multi-select.stories.tsx
+++ b/src/components/ui-multi-select/multi-select.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import React from 'react';
+import { expect, screen, userEvent, within } from 'storybook/test';
 
 import {
   booleanControlArgType,
@@ -16,6 +18,26 @@ const options: UiMultiSelectOption[] = [
   { label: 'Odesa', value: 'odesa' },
   { label: 'Kharkiv', value: 'kharkiv' },
 ];
+const citiesLabel: string = t('Cities');
+const citiesPlaceholder: string = t('Select cities');
+const firstPick: string = 'Lviv';
+const secondPick: string = 'Odesa';
+
+// The combobox is fully controlled, so the interaction story owns the chip set and
+// starts from an empty selection.
+function MultiSelectInteractionStory(): React.ReactElement {
+  const [value, setValue] = React.useState<UiMultiSelectOption[]>([]);
+
+  return (
+    <UiMultiSelect
+      options={options}
+      value={value}
+      label={citiesLabel}
+      placeholder={citiesPlaceholder}
+      onChange={setValue}
+    />
+  );
+}
 
 const meta: Meta<typeof UiMultiSelect> = {
   title: 'UiComponents/UiMultiSelect',
@@ -38,8 +60,26 @@ export const MultiSelect: Story = {
     options,
     // Two preselected chips give the visual baseline something to render.
     value: [options[0], options[2]],
-    label: t('Cities'),
-    placeholder: t('Select cities'),
+    label: citiesLabel,
+    placeholder: citiesPlaceholder,
     error: false,
+  },
+};
+
+// Interaction story (`interaction` tag): proves picking two options turns them into
+// chips inside the field. The listbox is portalled outside the story canvas, so it
+// is queried from `screen`. See tests/storybook/README.md.
+export const PickingOptionsAddsChips: Story = {
+  tags: ['interaction', '!autodocs'],
+  render: MultiSelectInteractionStory,
+  play: async ({ canvasElement }): Promise<void> => {
+    const canvas: ReturnType<typeof within> = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('combobox', { name: citiesLabel }));
+    await userEvent.click(await screen.findByRole('option', { name: firstPick }));
+    await userEvent.click(await screen.findByRole('option', { name: secondPick }));
+
+    await expect(canvas.getByText(firstPick)).toBeVisible();
+    await expect(canvas.getByText(secondPick)).toBeVisible();
   },
 };

--- a/src/components/ui-radio-group/radio-group.stories.tsx
+++ b/src/components/ui-radio-group/radio-group.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
 import React from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import {
   booleanControlArgType,
@@ -52,11 +53,39 @@ export default meta;
 
 type Story = StoryObj<typeof UiRadioGroup>;
 
+const groupLabel: string = t('Preferred contact method');
+const secondOptionLabel: string = 'SMS';
+const thirdOptionLabel: string = 'Push notification';
+
 export const RadioGroup: Story = {
   args: {
     options,
-    label: t('Preferred contact method'),
+    label: groupLabel,
     error: false,
   },
   render: (args: UiRadioGroupProps): React.ReactElement => <RadioGroupStory args={args} />,
+};
+
+// Interaction story (`interaction` tag): proves choosing a radio checks it and
+// unchecks the previous choice — the single-choice contract.
+// See tests/storybook/README.md.
+export const ChoosingOptionMovesSelection: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: {
+    options,
+    label: groupLabel,
+    error: false,
+  },
+  render: (args: UiRadioGroupProps): React.ReactElement => <RadioGroupStory args={args} />,
+  play: async ({ canvasElement }): Promise<void> => {
+    const canvas: ReturnType<typeof within> = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('radio', { name: secondOptionLabel }));
+    await expect(canvas.getByRole('radio', { name: secondOptionLabel })).toBeChecked();
+
+    await userEvent.click(canvas.getByRole('radio', { name: thirdOptionLabel }));
+
+    await expect(canvas.getByRole('radio', { name: thirdOptionLabel })).toBeChecked();
+    await expect(canvas.getByRole('radio', { name: secondOptionLabel })).not.toBeChecked();
+  },
 };

--- a/src/components/ui-search-input/search-input.stories.tsx
+++ b/src/components/ui-search-input/search-input.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
 import React from 'react';
-import { expect, screen, userEvent, within } from 'storybook/test';
 
 import {
   booleanControlArgType,
   textControlArgType,
 } from '../../../.storybook/field-story-arg-types';
+import { expectTypeaheadNarrowsAndSelects } from '../../../.storybook/field-typeahead-interactions';
 
 import UiSearchInput from './index';
 
@@ -57,21 +57,17 @@ export const SearchInput: Story = {
 };
 
 // Interaction story (`interaction` tag): proves typing filters the suggestions and
-// picking one writes it back into the field. The listbox is portalled outside the
-// story canvas, so it is queried from `screen`. See tests/storybook/README.md.
+// picking one writes it back into the field.
 export const SuggestionPickFillsField: Story = {
   tags: ['interaction', '!autodocs'],
   render: SearchInputInteractionStory,
   play: async ({ canvasElement }): Promise<void> => {
-    const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: searchLabel });
-
-    await userEvent.type(field, typedQuery);
-    const match: HTMLElement = await screen.findByRole('option', { name: chosenSuggestion });
-
-    await expect(screen.queryByRole('option', { name: filteredOutSuggestion })).toBeNull();
-
-    await userEvent.click(match);
-
-    await expect(field).toHaveValue(chosenSuggestion);
+    await expectTypeaheadNarrowsAndSelects({
+      canvasElement,
+      fieldName: searchLabel,
+      query: typedQuery,
+      chosenOption: chosenSuggestion,
+      filteredOutOption: filteredOutSuggestion,
+    });
   },
 };

--- a/src/components/ui-search-input/search-input.stories.tsx
+++ b/src/components/ui-search-input/search-input.stories.tsx
@@ -14,6 +14,7 @@ const suggestions: string[] = ['Top performers', 'Top sales this month', 'Top sa
 const searchLabel: string = t('Search');
 const typedQuery: string = 'Top sales';
 const chosenSuggestion: string = 'Top sales this year';
+const filteredOutSuggestion: string = 'Top performers';
 
 // The field is fully controlled, so the interaction story owns the search text.
 function SearchInputInteractionStory(): React.ReactElement {
@@ -65,7 +66,11 @@ export const SuggestionPickFillsField: Story = {
     const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: searchLabel });
 
     await userEvent.type(field, typedQuery);
-    await userEvent.click(await screen.findByRole('option', { name: chosenSuggestion }));
+    const match: HTMLElement = await screen.findByRole('option', { name: chosenSuggestion });
+
+    await expect(screen.queryByRole('option', { name: filteredOutSuggestion })).toBeNull();
+
+    await userEvent.click(match);
 
     await expect(field).toHaveValue(chosenSuggestion);
   },

--- a/src/components/ui-search-input/search-input.stories.tsx
+++ b/src/components/ui-search-input/search-input.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import React from 'react';
+import { expect, screen, userEvent, within } from 'storybook/test';
 
 import {
   booleanControlArgType,
@@ -9,6 +11,24 @@ import {
 import UiSearchInput from './index';
 
 const suggestions: string[] = ['Top performers', 'Top sales this month', 'Top sales this year'];
+const searchLabel: string = t('Search');
+const typedQuery: string = 'Top sales';
+const chosenSuggestion: string = 'Top sales this year';
+
+// The field is fully controlled, so the interaction story owns the search text.
+function SearchInputInteractionStory(): React.ReactElement {
+  const [value, setValue] = React.useState<string>('');
+
+  return (
+    <UiSearchInput
+      aria-label={searchLabel}
+      placeholder={searchLabel}
+      options={suggestions}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
 
 const meta: Meta<typeof UiSearchInput> = {
   title: 'UiComponents/UiSearchInput',
@@ -32,5 +52,21 @@ export const SearchInput: Story = {
     'aria-label': t('Search'),
     options: suggestions,
     error: false,
+  },
+};
+
+// Interaction story (`interaction` tag): proves typing filters the suggestions and
+// picking one writes it back into the field. The listbox is portalled outside the
+// story canvas, so it is queried from `screen`. See tests/storybook/README.md.
+export const SuggestionPickFillsField: Story = {
+  tags: ['interaction', '!autodocs'],
+  render: SearchInputInteractionStory,
+  play: async ({ canvasElement }): Promise<void> => {
+    const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: searchLabel });
+
+    await userEvent.type(field, typedQuery);
+    await userEvent.click(await screen.findByRole('option', { name: chosenSuggestion }));
+
+    await expect(field).toHaveValue(chosenSuggestion);
   },
 };

--- a/src/components/ui-select-with-search/select-with-search.stories.tsx
+++ b/src/components/ui-select-with-search/select-with-search.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import React from 'react';
+import { expect, screen, userEvent, within } from 'storybook/test';
 
 import {
   booleanControlArgType,
@@ -16,6 +18,25 @@ const options: UiSelectWithSearchOption[] = [
   { label: 'Odesa', value: 'odesa' },
   { label: 'Kharkiv', value: 'kharkiv' },
 ];
+const cityLabel: string = t('City');
+const cityPlaceholder: string = t('Search city');
+const typedQuery: string = 'Lv';
+const chosenCity: string = 'Lviv';
+
+// The combobox is fully controlled, so the interaction story owns the selection.
+function SelectWithSearchInteractionStory(): React.ReactElement {
+  const [value, setValue] = React.useState<UiSelectWithSearchOption | null>(null);
+
+  return (
+    <UiSelectWithSearch
+      options={options}
+      label={cityLabel}
+      placeholder={cityPlaceholder}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
 
 const meta: Meta<typeof UiSelectWithSearch> = {
   title: 'UiComponents/UiSelectWithSearch',
@@ -36,8 +57,24 @@ type Story = StoryObj<typeof UiSelectWithSearch>;
 export const SelectWithSearch: Story = {
   args: {
     options,
-    label: t('City'),
-    placeholder: t('Search city'),
+    label: cityLabel,
+    placeholder: cityPlaceholder,
     error: false,
+  },
+};
+
+// Interaction story (`interaction` tag): proves the search text narrows the
+// listbox and the picked option becomes the field's value.
+// See tests/storybook/README.md.
+export const SearchNarrowsAndSelectsOption: Story = {
+  tags: ['interaction', '!autodocs'],
+  render: SelectWithSearchInteractionStory,
+  play: async ({ canvasElement }): Promise<void> => {
+    const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: cityLabel });
+
+    await userEvent.type(field, typedQuery);
+    await userEvent.click(await screen.findByRole('option', { name: chosenCity }));
+
+    await expect(field).toHaveValue(chosenCity);
   },
 };

--- a/src/components/ui-select-with-search/select-with-search.stories.tsx
+++ b/src/components/ui-select-with-search/select-with-search.stories.tsx
@@ -22,6 +22,7 @@ const cityLabel: string = t('City');
 const cityPlaceholder: string = t('Search city');
 const typedQuery: string = 'Lv';
 const chosenCity: string = 'Lviv';
+const filteredOutCity: string = 'Odesa';
 
 // The combobox is fully controlled, so the interaction story owns the selection.
 function SelectWithSearchInteractionStory(): React.ReactElement {
@@ -73,7 +74,11 @@ export const SearchNarrowsAndSelectsOption: Story = {
     const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: cityLabel });
 
     await userEvent.type(field, typedQuery);
-    await userEvent.click(await screen.findByRole('option', { name: chosenCity }));
+    const match: HTMLElement = await screen.findByRole('option', { name: chosenCity });
+
+    await expect(screen.queryByRole('option', { name: filteredOutCity })).toBeNull();
+
+    await userEvent.click(match);
 
     await expect(field).toHaveValue(chosenCity);
   },

--- a/src/components/ui-select-with-search/select-with-search.stories.tsx
+++ b/src/components/ui-select-with-search/select-with-search.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
 import React from 'react';
-import { expect, screen, userEvent, within } from 'storybook/test';
 
 import {
   booleanControlArgType,
   textControlArgType,
 } from '../../../.storybook/field-story-arg-types';
+import { expectTypeaheadNarrowsAndSelects } from '../../../.storybook/field-typeahead-interactions';
 
 import type { UiSelectWithSearchOption } from './types';
 
@@ -66,20 +66,16 @@ export const SelectWithSearch: Story = {
 
 // Interaction story (`interaction` tag): proves the search text narrows the
 // listbox and the picked option becomes the field's value.
-// See tests/storybook/README.md.
 export const SearchNarrowsAndSelectsOption: Story = {
   tags: ['interaction', '!autodocs'],
   render: SelectWithSearchInteractionStory,
   play: async ({ canvasElement }): Promise<void> => {
-    const field: HTMLElement = within(canvasElement).getByRole('combobox', { name: cityLabel });
-
-    await userEvent.type(field, typedQuery);
-    const match: HTMLElement = await screen.findByRole('option', { name: chosenCity });
-
-    await expect(screen.queryByRole('option', { name: filteredOutCity })).toBeNull();
-
-    await userEvent.click(match);
-
-    await expect(field).toHaveValue(chosenCity);
+    await expectTypeaheadNarrowsAndSelects({
+      canvasElement,
+      fieldName: cityLabel,
+      query: typedQuery,
+      chosenOption: chosenCity,
+      filteredOutOption: filteredOutCity,
+    });
   },
 };

--- a/src/components/ui-text-field-form/text-field-form.stories.tsx
+++ b/src/components/ui-text-field-form/text-field-form.stories.tsx
@@ -2,6 +2,7 @@ import { Stack } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
 import { useForm } from 'react-hook-form';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import UiButton from '../ui-button';
 
@@ -69,22 +70,50 @@ function TextFieldFormStory(args: TextFieldFormStoryArgs): React.ReactElement {
   );
 }
 
+const submitLabel: string = t('Submit');
+const tooShortMessage: string = t('Name must be at least 3 characters');
+
+const textFieldFormArgs: Story['args'] = {
+  rules: {
+    required: t('This field is required'),
+    validate: (value: string) => {
+      if (value.length < 3) {
+        return tooShortMessage;
+      }
+      return true;
+    },
+  },
+  type: 'text',
+  placeholder: t('Enter text...'),
+  fullWidth: false,
+};
+
 export const TextFieldForm: Story = {
   // Storybook's render passes the story args through to the wrapper component.
   // eslint-disable-next-line react/jsx-props-no-spreading
   render: args => <TextFieldFormStory {...(args as TextFieldFormStoryArgs)} />,
-  args: {
-    rules: {
-      required: t('This field is required'),
-      validate: (value: string) => {
-        if (value.length < 3) {
-          return t('Name must be at least 3 characters');
-        }
-        return true;
-      },
-    },
-    type: 'text',
-    placeholder: t('Enter text...'),
-    fullWidth: false,
+  args: textFieldFormArgs,
+};
+
+// Interaction story (`interaction` tag): proves the field surfaces its validation
+// message on submit and clears it once the value becomes valid.
+// See tests/storybook/README.md.
+export const ValidationSurfacesFieldError: Story = {
+  tags: ['interaction', '!autodocs'],
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  render: args => <TextFieldFormStory {...(args as TextFieldFormStoryArgs)} />,
+  args: textFieldFormArgs,
+  play: async ({ canvasElement }): Promise<void> => {
+    const canvas: ReturnType<typeof within> = within(canvasElement);
+    const field: HTMLElement = canvas.getByRole('textbox');
+
+    await userEvent.type(field, 'ab');
+    await userEvent.click(canvas.getByRole('button', { name: submitLabel }));
+
+    await expect(await canvas.findByText(tooShortMessage)).toBeVisible();
+
+    await userEvent.type(field, 'c');
+
+    await waitFor((): Promise<void> => expect(canvas.queryByText(tooShortMessage)).toBeNull());
   },
 };

--- a/src/components/ui-tooltip/tooltip.stories.tsx
+++ b/src/components/ui-tooltip/tooltip.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { t } from 'i18next';
+import { expect, screen, userEvent, within } from 'storybook/test';
 
 import UiTooltip from '.';
+
+const disclosureTrigger: string = t('Plan details');
+const disclosureBody: string = t('Includes five seats');
 
 const meta: Meta<typeof UiTooltip> = {
   title: 'UiComponents/UITooltip',
@@ -41,5 +45,31 @@ export const Tooltip: Story = {
     placement: 'bottom',
     arrow: true,
     title: 'UiTooltip',
+  },
+};
+
+// Interaction story (`interaction` tag): proves the disclosure opens on click and
+// reports its state through `aria-expanded`. The bubble is portalled outside the
+// story canvas, so it is queried from `screen`. See tests/storybook/README.md.
+export const ClickOpensTooltip: Story = {
+  tags: ['interaction', '!autodocs'],
+  args: {
+    children: disclosureTrigger,
+    placement: 'bottom',
+    arrow: true,
+    title: disclosureBody,
+  },
+  play: async ({ canvasElement }): Promise<void> => {
+    const trigger: HTMLElement = within(canvasElement).getByRole('button', {
+      name: disclosureTrigger,
+    });
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(screen.queryByText(disclosureBody)).toBeNull();
+
+    await userEvent.click(trigger);
+
+    await expect(await screen.findByText(disclosureBody)).toBeInTheDocument();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
   },
 };

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -34,9 +34,11 @@ const config = {
     'lhci-reports-desktop/**',
     'lhci-reports-mobile/**',
     'tests/memory-leak/results/**',
-    '**/*.stories.tsx',
-    '**/*.stories.ts',
   ],
+  // Stories are excluded from `mutate` above but must still be COPIED into the
+  // sandbox: tests/unit/storybook-interaction-coverage.test.ts scans them from
+  // disk, and an ignored story file would make that drift guard see an empty
+  // library and fail every mutant run.
   thresholds: { high: 90, break: 80 },
 };
 

--- a/tests/bats/doc_make_target_coverage.bats
+++ b/tests/bats/doc_make_target_coverage.bats
@@ -18,7 +18,7 @@ load './test_helper.bash'
 # such as memory-leak and lighthouse are documented in agents.md but not listed
 # here); keep it in sync with the README table. Adding a target here means it
 # must be documented in README.md or agents.md.
-GATING_TARGETS=(lint test-unit test-integration test-e2e test-visual test-mutation test-bats)
+GATING_TARGETS=(lint test-unit test-integration test-e2e test-visual test-storybook test-mutation test-bats)
 
 # Print, one per line, every `make <target>` invocation that appears in a CODE
 # context (a fenced code block or an inline `code` span) of the given Markdown

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -35,6 +35,7 @@ test-memory-leak	bats	tests/bats/makefile_targets.bats	Validated as the inline M
 test-mutation	ci	.github/workflows/mutation-testing.yml	Executed directly by the mutation testing workflow.
 test-unit	bats	tests/bats/makefile_targets.bats	Validated for both the running-container and fresh-container branches.
 test-visual	bats	tests/bats/makefile_targets.bats	Validated as the Storybook-backed visual flow delegated through the shared helper target.
+test-storybook	bats	tests/bats/makefile_targets.bats	Validated as the Storybook interaction (play function) flow delegated through the shared helper target.
 up	ci	.github/workflows/static-testing.yml	Exercised transitively by workflows that call `make start`, which depends on `up`.
 update	bats	tests/bats/makefile_targets.bats	Validated as the Bun dependency update command.
 test-integration	bats	tests/bats/makefile_targets.bats	Validated for both the running-container and fresh-container branches.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -68,6 +68,7 @@ EOF
 test-e2e|docker compose build playwright|docker compose up -d --build storybook|docker compose run --rm playwright sh -lc bun x wait-on --timeout 120000 http-get://storybook:6006/iframe.html|docker compose run --rm playwright bun x playwright test ./tests/e2e
 test-visual|docker compose build playwright|docker compose up -d --build storybook|docker compose run --rm playwright sh -lc bun x wait-on --timeout 120000 http-get://storybook:6006/iframe.html|docker compose run --rm playwright bun x playwright test ./tests/visual --pass-with-no-tests
 test-memory-leak|if [ ! -f tests/memory-leak/runMemlabTests.js ]; then|Skipping memory leak tests because this bootstrap PR does not include the app test files yet.|bun x storybook dev --ci --host 0.0.0.0 -p 3000|MEMLAB_WEBSITE_URL=http://127.0.0.1:3000 bun ./tests/memory-leak/runMemlabTests.js
+test-storybook|docker compose build playwright|docker compose up -d --build storybook|docker compose run --rm playwright sh -lc bun x wait-on --timeout 120000 http-get://storybook:6006/iframe.html|docker compose run --rm playwright bun scripts/ci/run-storybook-interactions.ts tests/storybook/interaction-stories.json
 EOF
 }
 
@@ -83,7 +84,24 @@ EOF
   done <<'EOF'
 test-e2e|docker compose -f docker-compose.override.yml build playwright
 test-visual|docker compose -f docker-compose.override.yml build playwright
+test-storybook|docker compose -f docker-compose.override.yml build playwright
 EOF
+}
+
+@test "test-storybook runs the interaction gate instead of a Playwright spec run" {
+  reset_command_log
+  run_make_target test-storybook
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose run --rm playwright bun scripts/ci/run-storybook-interactions.ts'
+  assert_log_not_contains 'bun x playwright test'
+}
+
+@test "the shared helper still defaults to the Playwright runner for other targets" {
+  reset_command_log
+  run_make_target test-e2e
+  [ "$status" -eq 0 ]
+  assert_log_contains 'docker compose run --rm playwright bun x playwright test ./tests/e2e'
+  assert_log_not_contains 'run-storybook-interactions.ts'
 }
 
 @test "load-tests builds the k6 image and runs the homepage scenario" {

--- a/tests/storybook/README.md
+++ b/tests/storybook/README.md
@@ -30,7 +30,10 @@ vanished from the whole library. The suite fails closed instead.
 2. Tag it `tags: ['interaction', '!autodocs']` and write the `play` function with
    `within`, `userEvent` and `expect` imported from `storybook/test`. Pass explicit
    `fn()` spies for the handlers you assert on — an implicit action arg throws when
-   a play function invokes it.
+   a play function invokes it. When a second component needs the same interaction,
+   move the body into `.storybook/` (as `field-typeahead-interactions.ts` does for
+   the typeahead fields) instead of copying it — duplicated play bodies are a
+   duplication finding, and the two copies drift apart.
 3. Rebuild Storybook (`make storybook-build`, or `bun x storybook build`) and
    regenerate both manifests from the fresh index — `../visual/stories.json` (every
    story, see `../visual/README.md`) and this one (the `interaction`-tagged subset,

--- a/tests/storybook/README.md
+++ b/tests/storybook/README.md
@@ -31,9 +31,19 @@ vanished from the whole library. The suite fails closed instead.
    `within`, `userEvent` and `expect` imported from `storybook/test`. Pass explicit
    `fn()` spies for the handlers you assert on — an implicit action arg throws when
    a play function invokes it.
-3. Regenerate both manifests (see `../visual/README.md` for the story-index
-   snippet); `interaction-stories.json` keeps the `interaction`-tagged subset plus
-   each story's `exportName`.
+3. Rebuild Storybook (`make storybook-build`, or `bun x storybook build`) and
+   regenerate both manifests from the fresh index — `../visual/stories.json` (every
+   story, see `../visual/README.md`) and this one (the `interaction`-tagged subset,
+   plus each story's `exportName`):
+
+   ```bash
+   node -e 'const j=require("./storybook-static/index.json");const fs=require("fs");\
+   const tagged=e=>e.type==="story"&&(e.tags||[]).includes("interaction");\
+   const s=Object.values(j.entries).filter(tagged)\
+   .map(e=>({id:e.id,title:e.title,name:e.name,exportName:e.exportName}))\
+   .sort((a,b)=>a.id.localeCompare(b.id));\
+   fs.writeFileSync("tests/storybook/interaction-stories.json",JSON.stringify(s,null,2)+"\n")'
+   ```
 
 `tests/unit/storybook-interaction-coverage.test.ts` statically scans the story
 sources, so a `play` function that is not tagged and registered fails the unit

--- a/tests/storybook/README.md
+++ b/tests/storybook/README.md
@@ -1,0 +1,47 @@
+# Storybook interaction tests
+
+Behavioural coverage of the library's stories: every interactive component ships a
+story whose `play` function drives it the way a user would — in a real browser,
+against the Storybook build the library actually publishes.
+
+## What runs
+
+`make test-storybook` boots the `storybook` service, then runs
+`scripts/ci/run-storybook-interactions.ts` inside the Playwright image. That script
+is the gate:
+
+1. **Before the run** it fetches the live `index.json` and asserts that the stories
+   tagged `interaction` are exactly the ones registered in
+   `interaction-stories.json`, and that at least `MINIMUM_COMPONENTS` distinct
+   components are covered.
+2. **The run** is `@storybook/test-runner --includeTags interaction`, chromium only.
+3. **After the run** it reads the JUnit report and asserts one _passing_
+   `play-test` per registered story — no failures, no skips.
+
+Step 1 and step 3 exist because `--includeTags` rewrites every story file without a
+matching story into a skipped no-op suite: Jest alone would exit `0` if the tag
+vanished from the whole library. The suite fails closed instead.
+
+## Adding an interaction
+
+1. Add a new story export to the component's `*.stories.tsx` — never bolt `play`
+   onto an existing story. Existing stories are pinned by visual baselines, and
+   Storybook autoplays `play` as soon as the canvas renders.
+2. Tag it `tags: ['interaction', '!autodocs']` and write the `play` function with
+   `within`, `userEvent` and `expect` imported from `storybook/test`. Pass explicit
+   `fn()` spies for the handlers you assert on — an implicit action arg throws when
+   a play function invokes it.
+3. Regenerate both manifests (see `../visual/README.md` for the story-index
+   snippet); `interaction-stories.json` keeps the `interaction`-tagged subset plus
+   each story's `exportName`.
+
+`tests/unit/storybook-interaction-coverage.test.ts` statically scans the story
+sources, so a `play` function that is not tagged and registered fails the unit
+suite, and `tests/visual/visual.spec.ts` asserts the pixel-exemption list and this
+registry are the same set.
+
+## Why interaction stories have no pixel baseline
+
+Their canvas mutates itself asynchronously, so a screenshot races the `play` phase
+and could capture any intermediate frame. They are proven behaviourally here and
+still covered by the e2e smoke suite (mount + no page error, on all three engines).

--- a/tests/storybook/interaction-stories.json
+++ b/tests/storybook/interaction-stories.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "uicomponents-uibacktomain--keyboard-focus-reaches-back-link",
+    "title": "UiComponents/UiBackToMain",
+    "name": "Keyboard Focus Reaches Back Link",
+    "exportName": "KeyboardFocusReachesBackLink"
+  },
+  {
+    "id": "uicomponents-uibutton--click-invokes-handler",
+    "title": "UiComponents/UiButton",
+    "name": "Click Invokes Handler",
+    "exportName": "ClickInvokesHandler"
+  },
+  {
+    "id": "uicomponents-uicalendarmultiselect--day-toggle-updates-selection",
+    "title": "UiComponents/UiCalendarMultiSelect",
+    "name": "Day Toggle Updates Selection",
+    "exportName": "DayToggleUpdatesSelection"
+  },
+  {
+    "id": "uicomponents-uicheckbox--click-toggles-checked-state",
+    "title": "UiComponents/UiCheckbox",
+    "name": "Click Toggles Checked State",
+    "exportName": "ClickTogglesCheckedState"
+  },
+  {
+    "id": "uicomponents-uiform--validation-blocks-empty-submit",
+    "title": "UiComponents/UiForm",
+    "name": "Validation Blocks Empty Submit",
+    "exportName": "ValidationBlocksEmptySubmit"
+  },
+  {
+    "id": "uicomponents-uiinput--typing-updates-value",
+    "title": "UiComponents/UiInput",
+    "name": "Typing Updates Value",
+    "exportName": "TypingUpdatesValue"
+  },
+  {
+    "id": "uicomponents-uilink--keyboard-focus-exposes-new-tab-hint",
+    "title": "UiComponents/UiLink",
+    "name": "Keyboard Focus Exposes New Tab Hint",
+    "exportName": "KeyboardFocusExposesNewTabHint"
+  },
+  {
+    "id": "uicomponents-uimultiselect--picking-options-adds-chips",
+    "title": "UiComponents/UiMultiSelect",
+    "name": "Picking Options Adds Chips",
+    "exportName": "PickingOptionsAddsChips"
+  },
+  {
+    "id": "uicomponents-uiradiogroup--choosing-option-moves-selection",
+    "title": "UiComponents/UiRadioGroup",
+    "name": "Choosing Option Moves Selection",
+    "exportName": "ChoosingOptionMovesSelection"
+  },
+  {
+    "id": "uicomponents-uisearchinput--suggestion-pick-fills-field",
+    "title": "UiComponents/UiSearchInput",
+    "name": "Suggestion Pick Fills Field",
+    "exportName": "SuggestionPickFillsField"
+  },
+  {
+    "id": "uicomponents-uiselectwithsearch--search-narrows-and-selects-option",
+    "title": "UiComponents/UiSelectWithSearch",
+    "name": "Search Narrows And Selects Option",
+    "exportName": "SearchNarrowsAndSelectsOption"
+  },
+  {
+    "id": "uicomponents-uitextfieldform--validation-surfaces-field-error",
+    "title": "UiComponents/UiTextFieldForm",
+    "name": "Validation Surfaces Field Error",
+    "exportName": "ValidationSurfacesFieldError"
+  },
+  {
+    "id": "uicomponents-uitooltip--click-opens-tooltip",
+    "title": "UiComponents/UITooltip",
+    "name": "Click Opens Tooltip",
+    "exportName": "ClickOpensTooltip"
+  }
+]

--- a/tests/unit/storybook-interaction-coverage.test.ts
+++ b/tests/unit/storybook-interaction-coverage.test.ts
@@ -48,11 +48,23 @@ function sourceStories(): SourceStory[] {
   });
 }
 
+const sources: string[] = storyFiles(path.join(projectRoot, 'src'));
 const scanned: SourceStory[] = sourceStories();
 const key = (story: { title: string; exportName: string }): string =>
   `${story.title} ${story.exportName}`;
 
 describe('Storybook interaction manifest', () => {
+  it('reads a meta title out of every story file', () => {
+    // `sourceStories` drops files whose title it cannot read; without this,
+    // an unparsable story file would silently hide its play functions.
+    const untitled: string[] = sources.filter(
+      file => scanMetaTitle(file, fs.readFileSync(file, 'utf8')) === null
+    );
+
+    expect(sources.length).toBeGreaterThan(0);
+    expect(untitled).toEqual([]);
+  });
+
   it('is not empty and covers at least the required number of components', () => {
     expect(manifest.length).toBeGreaterThan(0);
     expect(new Set(manifest.map(story => story.title)).size).toBeGreaterThanOrEqual(

--- a/tests/unit/storybook-interaction-coverage.test.ts
+++ b/tests/unit/storybook-interaction-coverage.test.ts
@@ -1,0 +1,137 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  scanMetaTitle,
+  scanStories,
+  type ScannedStory,
+} from '../../scripts/ci/story-play-functions';
+import {
+  INTERACTION_TAG,
+  MINIMUM_COMPONENTS,
+  formatDrift,
+  junitPlayTestKeys,
+  liveInteractionStories,
+  type InteractionStory,
+} from '../../scripts/ci/storybook-interaction-manifest';
+
+// Drift guard for the Storybook interaction (play function) suite — the
+// "fail-if-absent from day one" half of issue #100. `make test-storybook` proves
+// the registered play functions PASS in a real browser; this suite proves the
+// registry itself cannot silently shrink or fall out of sync with the sources.
+
+const projectRoot: string = path.resolve(__dirname, '../..');
+const manifestPath: string = path.join(projectRoot, 'tests/storybook/interaction-stories.json');
+const storiesManifestPath: string = path.join(projectRoot, 'tests/visual/stories.json');
+
+type StoryEntry = { id: string; title: string; name: string };
+
+const manifest: InteractionStory[] = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const allStories: StoryEntry[] = JSON.parse(fs.readFileSync(storiesManifestPath, 'utf8'));
+
+function storyFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const full: string = path.join(directory, entry.name);
+    if (entry.isDirectory()) return storyFiles(full);
+    return entry.name.endsWith('.stories.tsx') ? [full] : [];
+  });
+}
+
+type SourceStory = ScannedStory & { title: string };
+
+function sourceStories(): SourceStory[] {
+  return storyFiles(path.join(projectRoot, 'src')).flatMap(file => {
+    const source: string = fs.readFileSync(file, 'utf8');
+    const title: string | null = scanMetaTitle(file, source);
+    if (title === null) return [];
+    return scanStories(file, source).map(story => ({ ...story, title }));
+  });
+}
+
+const scanned: SourceStory[] = sourceStories();
+const key = (story: { title: string; exportName: string }): string =>
+  `${story.title} ${story.exportName}`;
+
+describe('Storybook interaction manifest', () => {
+  it('is not empty and covers at least the required number of components', () => {
+    expect(manifest.length).toBeGreaterThan(0);
+    expect(new Set(manifest.map(story => story.title)).size).toBeGreaterThanOrEqual(
+      MINIMUM_COMPONENTS
+    );
+  });
+
+  it('registers exactly the stories that declare a play function', () => {
+    const declared: string[] = scanned.filter(story => story.hasPlay).map(key);
+
+    expect(formatDrift(manifest.map(key), declared)).toBeNull();
+  });
+
+  it('requires every registered story to carry the interaction tag', () => {
+    const registered: Set<string> = new Set(manifest.map(key));
+    const untagged: string[] = scanned
+      .filter(story => registered.has(key(story)) && !story.tags.includes(INTERACTION_TAG))
+      .map(key);
+
+    expect(untagged).toEqual([]);
+  });
+
+  it('only registers stories that the shared story manifest knows about', () => {
+    const live: Set<string> = new Set(allStories.map(story => `${story.id}|${story.title}`));
+    const unknown: string[] = manifest
+      .filter(story => !live.has(`${story.id}|${story.title}`))
+      .map(story => story.id);
+
+    expect(unknown).toEqual([]);
+  });
+});
+
+describe('interaction gate helpers', () => {
+  it('reads interaction-tagged stories out of a live Storybook index', () => {
+    const index = {
+      entries: {
+        a: { type: 'docs', id: 'a', title: 'T', name: 'Docs', tags: ['interaction'] },
+        b: {
+          type: 'story',
+          id: 'b',
+          title: 'T',
+          name: 'Plain',
+          exportName: 'Plain',
+          tags: ['dev'],
+        },
+        c: {
+          type: 'story',
+          id: 'c',
+          title: 'T',
+          name: 'Play',
+          exportName: 'Play',
+          tags: ['interaction'],
+        },
+        d: { type: 'story', id: 'd' },
+      },
+    };
+
+    expect(liveInteractionStories(index)).toEqual([
+      { id: 'c', title: 'T', name: 'Play', exportName: 'Play' },
+    ]);
+    expect(liveInteractionStories(null)).toEqual([]);
+  });
+
+  it('counts only passing play tests in a JUnit report', () => {
+    const report: string = [
+      // jest-junit writes a passing case either self-closing or with an empty body.
+      '<testcase classname="T A play-test" name="T A play-test" time="1"/>',
+      '<testcase classname="T D play-test" name="T D play-test" time="0.26">\n</testcase>',
+      '<testcase classname="T B play-test" name="T B play-test"><skipped/></testcase>',
+      '<testcase classname="T C play-test" name="T C play-test"><failure>boom</failure></testcase>',
+      '<testcase classname="T E play-test" name="T E play-test"><error>died</error></testcase>',
+      '<testcase classname="T no-op" name="T no-op" time="0"/>',
+    ].join('\n');
+
+    expect(junitPlayTestKeys(report)).toEqual(['T A', 'T D']);
+  });
+
+  it('reports both missing and unregistered keys', () => {
+    expect(formatDrift(['a', 'b'], ['b', 'c'])).toBe('  - missing: a\n  - unregistered: c');
+    expect(formatDrift(['a'], ['a'])).toBeNull();
+  });
+});

--- a/tests/unit/storybook-interaction-coverage.test.ts
+++ b/tests/unit/storybook-interaction-coverage.test.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import {
+  isStoryFile,
   scanMetaTitle,
   scanStories,
   type ScannedStory,
@@ -9,9 +11,12 @@ import {
 import {
   INTERACTION_TAG,
   MINIMUM_COMPONENTS,
+  duplicateKeys,
   formatDrift,
+  interactionStoryKeys,
   junitPlayTestKeys,
   liveInteractionStories,
+  playTestKeys,
   type InteractionStory,
 } from '../../scripts/ci/storybook-interaction-manifest';
 
@@ -33,7 +38,9 @@ function storyFiles(directory: string): string[] {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
     const full: string = path.join(directory, entry.name);
     if (entry.isDirectory()) return storyFiles(full);
-    return entry.name.endsWith('.stories.tsx') ? [full] : [];
+    // Every CSF flavour Storybook loads — a non-TSX story module must not escape
+    // the scan, or it could carry an unregistered `play` function.
+    return isStoryFile(entry.name) ? [full] : [];
   });
 }
 
@@ -87,12 +94,13 @@ describe('Storybook interaction manifest', () => {
     expect(untagged).toEqual([]);
   });
 
-  it('registers each story exactly once', () => {
-    const keys: string[] = manifest.map(key);
-
-    // The gate's drift comparison is set-based, so a duplicated row would inflate
-    // the registry without demanding a second passing play test.
-    expect(keys).toEqual([...new Set(keys)]);
+  it('registers each story exactly once in both of the gate comparison key spaces', () => {
+    // Both drift comparisons are set-based, so a row duplicated in either key
+    // space would inflate the registry without demanding a second passing play
+    // test — the id space is reconciled against the live Storybook index, the
+    // title+exportName space against the JUnit report.
+    expect(duplicateKeys(interactionStoryKeys(manifest))).toEqual([]);
+    expect(duplicateKeys(playTestKeys(manifest))).toEqual([]);
   });
 
   it('only registers stories that the shared story manifest knows about', () => {
@@ -167,6 +175,79 @@ describe('interaction gate helpers', () => {
     expect(scanStories('wrapped.stories.tsx', source)).toEqual([
       { exportName: 'Plain', hasPlay: true, tags: ['interaction'] },
     ]);
+  });
+
+  it('reads the title off the object `export default` names, not the first one', () => {
+    // A titled helper declared ABOVE `meta` must not win: taking the first
+    // declared title would key the manifest check on the wrong component.
+    const source: string = [
+      "const docsPage = { title: 'Decoy/NotTheMeta' };",
+      "const meta = { title: 'Real/Meta', parameters: { docs: docsPage } };",
+      'export default meta;',
+    ].join('\n');
+
+    expect(scanMetaTitle('decoy.stories.tsx', source)).toBe('Real/Meta');
+  });
+
+  it('reports no title when the default export is missing or is not an object', () => {
+    expect(scanMetaTitle('orphan.stories.tsx', "const meta = { title: 'Orphan' };")).toBeNull();
+    expect(scanMetaTitle('absent.stories.tsx', 'export default composeMeta();')).toBeNull();
+    expect(scanMetaTitle('unknown.stories.tsx', 'export default notDeclaredHere;')).toBeNull();
+  });
+
+  it('treats every CSF flavour `.storybook/main.ts` loads as a story file', () => {
+    // The glob there is `*.stories.@(js|jsx|mjs|ts|tsx)`; anything this predicate
+    // misses is a module that can carry an unregistered `play` function.
+    const loaded: string[] = ['js', 'jsx', 'mjs', 'ts', 'tsx'].map(ext => `x.stories.${ext}`);
+
+    expect(loaded.filter(isStoryFile)).toEqual(loaded);
+    expect(
+      ['x.stories.mdx', 'x.story.ts', 'x.stories.ts.bak', 'stories.ts'].some(isStoryFile)
+    ).toBe(false);
+  });
+
+  it('scans TypeScript-only CSF modules the same way as TSX ones', () => {
+    // A bare generic arrow is valid TS but reads as an unclosed JSX tag under TSX
+    // rules, so this fixture also pins the per-extension parser choice.
+    const source: string = [
+      'const pick = <T>(values: T[]): T => values[0];',
+      "const meta = { title: 'TsOnly/Meta', args: { items: pick([[1]]) } };",
+      'export default meta;',
+      "export const Play = { tags: ['interaction'], play: async () => {} };",
+    ].join('\n');
+
+    expect(scanMetaTitle('ts-only.stories.ts', source)).toBe('TsOnly/Meta');
+    expect(scanStories('ts-only.stories.ts', source)).toEqual([
+      { exportName: 'Play', hasPlay: true, tags: ['interaction'] },
+    ]);
+  });
+
+  it('walks a real directory tree and picks up every story flavour in it', () => {
+    // The source-string fixtures above prove the parser; this proves the on-disk
+    // discovery walk, which is what a `.stories.ts` module would have bypassed.
+    const root: string = fs.mkdtempSync(path.join(os.tmpdir(), 'story-walk-'));
+
+    try {
+      fs.mkdirSync(path.join(root, 'nested'));
+      ['a.stories.ts', 'b.stories.tsx', 'c.stories.mdx', 'd.ts'].forEach(name =>
+        fs.writeFileSync(path.join(root, name), '')
+      );
+      fs.writeFileSync(path.join(root, 'nested', 'e.stories.js'), '');
+
+      expect(
+        storyFiles(root)
+          .map(file => path.relative(root, file))
+          .sort()
+      ).toEqual(['a.stories.ts', 'b.stories.tsx', path.join('nested', 'e.stories.js')]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports every key a manifest lists more than once', () => {
+    expect(duplicateKeys(['b', 'a', 'b', 'c', 'a'])).toEqual(['a', 'b']);
+    expect(duplicateKeys(['a', 'b'])).toEqual([]);
+    expect(playTestKeys([{ id: 'i', title: 'T', name: 'N', exportName: 'E' }])).toEqual(['T E']);
   });
 
   it('reports both missing and unregistered keys', () => {

--- a/tests/unit/storybook-interaction-coverage.test.ts
+++ b/tests/unit/storybook-interaction-coverage.test.ts
@@ -87,6 +87,14 @@ describe('Storybook interaction manifest', () => {
     expect(untagged).toEqual([]);
   });
 
+  it('registers each story exactly once', () => {
+    const keys: string[] = manifest.map(key);
+
+    // The gate's drift comparison is set-based, so a duplicated row would inflate
+    // the registry without demanding a second passing play test.
+    expect(keys).toEqual([...new Set(keys)]);
+  });
+
   it('only registers stories that the shared story manifest knows about', () => {
     const live: Set<string> = new Set(allStories.map(story => `${story.id}|${story.title}`));
     const unknown: string[] = manifest
@@ -140,6 +148,25 @@ describe('interaction gate helpers', () => {
     ].join('\n');
 
     expect(junitPlayTestKeys(report)).toEqual(['T A', 'T D']);
+  });
+
+  it('decodes XML entities in JUnit test names', () => {
+    const report: string =
+      '<testcase classname="c" name="Ui &amp; Co &lt;B&gt; play-test" time="1"/>';
+
+    expect(junitPlayTestKeys(report)).toEqual(['Ui & Co <B>']);
+  });
+
+  it('sees through `as` and `satisfies` wrappers and a direct default export', () => {
+    const source: string = [
+      "export default { title: 'Wrapped/Meta' } as Meta;",
+      "export const Plain = { tags: ['interaction'], play: async () => {} } satisfies Story;",
+    ].join('\n');
+
+    expect(scanMetaTitle('wrapped.stories.tsx', source)).toBe('Wrapped/Meta');
+    expect(scanStories('wrapped.stories.tsx', source)).toEqual([
+      { exportName: 'Plain', hasPlay: true, tags: ['interaction'] },
+    ]);
   });
 
   it('reports both missing and unregistered keys', () => {

--- a/tests/unit/storybook-interaction-coverage.test.ts
+++ b/tests/unit/storybook-interaction-coverage.test.ts
@@ -189,6 +189,26 @@ describe('interaction gate helpers', () => {
     expect(scanMetaTitle('decoy.stories.tsx', source)).toBe('Real/Meta');
   });
 
+  it('resolves a meta aliased with `export { meta as default }`', () => {
+    // The alias form is a plain ExportDeclaration, not an ExportAssignment; missing
+    // it would make the drift guard reject a perfectly valid story file as untitled.
+    const source: string = [
+      "const helper = { title: 'Decoy/NotTheMeta' };",
+      "const meta = { title: 'Aliased/Meta', parameters: helper };",
+      'export { meta as default };',
+    ].join('\n');
+
+    expect(scanMetaTitle('aliased.stories.tsx', source)).toBe('Aliased/Meta');
+  });
+
+  it('does not resolve a default re-exported from another module', () => {
+    // `export { meta as default } from './other'` declares nothing locally, so
+    // there is no initializer to read — failing loudly beats guessing.
+    const source: string = "export { meta as default } from './other-meta';";
+
+    expect(scanMetaTitle('reexport.stories.tsx', source)).toBeNull();
+  });
+
   it('reports no title when the default export is missing or is not an object', () => {
     expect(scanMetaTitle('orphan.stories.tsx', "const meta = { title: 'Orphan' };")).toBeNull();
     expect(scanMetaTitle('absent.stories.tsx', 'export default composeMeta();')).toBeNull();

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -11,6 +11,11 @@ Pixel baselines for every Storybook story, asserted with Playwright
   `test.skip` on any non-chromium project.
 - One snapshot per story. The story list lives in `stories.json`, derived from the
   Storybook index and committed so the run is identical locally and in Docker.
+- **Except interaction stories.** Stories registered in
+  `../storybook/interaction-stories.json` autoplay a `play` function that mutates
+  their own canvas, so a screenshot would race the interaction. They are pixel-exempt
+  and proven behaviourally by `make test-storybook`; `visual.spec.ts` asserts the
+  exempt set and that registry are identical, so a story can never fall out of both.
 - Shots are deterministic: `prefers-reduced-motion: reduce` is emulated (which also
   exercises the skeleton reduced-motion guard) and an injected stylesheet disables
   every `animation`/`transition`, so shimmer/pulse never flake the diff.

--- a/tests/visual/stories.json
+++ b/tests/visual/stories.json
@@ -40,6 +40,16 @@
     "name": "Default"
   },
   {
+    "id": "uicomponents-uibacktomain--keyboard-focus-reaches-back-link",
+    "title": "UiComponents/UiBackToMain",
+    "name": "Keyboard Focus Reaches Back Link"
+  },
+  {
+    "id": "uicomponents-uibutton--click-invokes-handler",
+    "title": "UiComponents/UiButton",
+    "name": "Click Invokes Handler"
+  },
+  {
     "id": "uicomponents-uibutton--contained",
     "title": "UiComponents/UiButton",
     "name": "Contained"
@@ -58,6 +68,11 @@
     "id": "uicomponents-uicalendarmultiselect--calendar-multi-select",
     "title": "UiComponents/UiCalendarMultiSelect",
     "name": "Calendar Multi Select"
+  },
+  {
+    "id": "uicomponents-uicalendarmultiselect--day-toggle-updates-selection",
+    "title": "UiComponents/UiCalendarMultiSelect",
+    "name": "Day Toggle Updates Selection"
   },
   {
     "id": "uicomponents-uicarditem--card-item-large",
@@ -85,6 +100,11 @@
     "name": "Checkbox"
   },
   {
+    "id": "uicomponents-uicheckbox--click-toggles-checked-state",
+    "title": "UiComponents/UiCheckbox",
+    "name": "Click Toggles Checked State"
+  },
+  {
     "id": "uicomponents-uicontainer--default",
     "title": "UiComponents/UiContainer",
     "name": "Default"
@@ -110,6 +130,11 @@
     "name": "Submitting"
   },
   {
+    "id": "uicomponents-uiform--validation-blocks-empty-submit",
+    "title": "UiComponents/UiForm",
+    "name": "Validation Blocks Empty Submit"
+  },
+  {
     "id": "uicomponents-uiform--with-error",
     "title": "UiComponents/UiForm",
     "name": "With Error"
@@ -125,6 +150,16 @@
     "name": "Input"
   },
   {
+    "id": "uicomponents-uiinput--typing-updates-value",
+    "title": "UiComponents/UiInput",
+    "name": "Typing Updates Value"
+  },
+  {
+    "id": "uicomponents-uilink--keyboard-focus-exposes-new-tab-hint",
+    "title": "UiComponents/UiLink",
+    "name": "Keyboard Focus Exposes New Tab Hint"
+  },
+  {
     "id": "uicomponents-uilink--link",
     "title": "UiComponents/UiLink",
     "name": "Link"
@@ -135,6 +170,16 @@
     "name": "Multi Select"
   },
   {
+    "id": "uicomponents-uimultiselect--picking-options-adds-chips",
+    "title": "UiComponents/UiMultiSelect",
+    "name": "Picking Options Adds Chips"
+  },
+  {
+    "id": "uicomponents-uiradiogroup--choosing-option-moves-selection",
+    "title": "UiComponents/UiRadioGroup",
+    "name": "Choosing Option Moves Selection"
+  },
+  {
     "id": "uicomponents-uiradiogroup--radio-group",
     "title": "UiComponents/UiRadioGroup",
     "name": "Radio Group"
@@ -143,6 +188,16 @@
     "id": "uicomponents-uisearchinput--search-input",
     "title": "UiComponents/UiSearchInput",
     "name": "Search Input"
+  },
+  {
+    "id": "uicomponents-uisearchinput--suggestion-pick-fills-field",
+    "title": "UiComponents/UiSearchInput",
+    "name": "Suggestion Pick Fills Field"
+  },
+  {
+    "id": "uicomponents-uiselectwithsearch--search-narrows-and-selects-option",
+    "title": "UiComponents/UiSelectWithSearch",
+    "name": "Search Narrows And Selects Option"
   },
   {
     "id": "uicomponents-uiselectwithsearch--select-with-search",
@@ -200,9 +255,19 @@
     "name": "Text Field Form"
   },
   {
+    "id": "uicomponents-uitextfieldform--validation-surfaces-field-error",
+    "title": "UiComponents/UiTextFieldForm",
+    "name": "Validation Surfaces Field Error"
+  },
+  {
     "id": "uicomponents-uitoolbar--toolbar",
     "title": "UiComponents/UiToolbar",
     "name": "Toolbar"
+  },
+  {
+    "id": "uicomponents-uitooltip--click-opens-tooltip",
+    "title": "UiComponents/UITooltip",
+    "name": "Click Opens Tooltip"
   },
   {
     "id": "uicomponents-uitooltip--tooltip",

--- a/tests/visual/visual.spec.ts
+++ b/tests/visual/visual.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
+import interactionStories from '../storybook/interaction-stories.json';
+
 import stories from './stories.json';
 
 // Visual regression runs on a single engine (chromium): pixel baselines are
@@ -9,6 +11,19 @@ import stories from './stories.json';
 
 type StoryEntry = { id: string; title: string; name: string };
 type IndexEntry = { type: string; id: string };
+
+// Interaction stories drive their own canvas: Storybook autoplays their `play`
+// function the moment the story renders, so a screenshot races the interaction and
+// can capture any intermediate frame. They are pixel-exempt here and proven
+// behaviourally by `make test-storybook` instead. The exemption is not a hole — the
+// manifest below is the same registry that gate reads, and the last test in this
+// file asserts an id may only skip a baseline while it is registered there.
+const interactionIds: Set<string> = new Set(
+  (interactionStories as StoryEntry[]).map(entry => entry.id)
+);
+const pixelStories: StoryEntry[] = (stories as StoryEntry[]).filter(
+  story => !interactionIds.has(story.id)
+);
 
 const FREEZE_CSS = `
   *, *::before, *::after {
@@ -36,7 +51,7 @@ test.describe('Visual regression (Storybook stories)', () => {
 
   test.use({ viewport: { width: 1280, height: 720 } });
 
-  for (const story of stories as StoryEntry[]) {
+  for (const story of pixelStories) {
     test(`${story.title} — ${story.name}`, async ({ page }) => {
       await openFrozenStory(page, story.id);
 
@@ -68,4 +83,18 @@ test('the manifest has a baseline target for every live Storybook story', async 
   // Every story must be in the manifest the screenshot loop iterates — so no
   // story can ship without a visual baseline (100% story coverage).
   expect(manifestIds).toEqual(liveStoryIds);
+});
+
+test('every story without a pixel baseline is a registered interaction story', () => {
+  const exempt: string[] = (stories as StoryEntry[])
+    .map(story => story.id)
+    .filter(id => interactionIds.has(id))
+    .sort((a, b) => a.localeCompare(b));
+  const registered: string[] = [...interactionIds].sort((a, b) => a.localeCompare(b));
+
+  // Reciprocal of the completeness test above: the only stories the screenshot
+  // loop skips are the ones `tests/storybook/interaction-stories.json` registers,
+  // and every registered id is a real story. Coverage can move between the two
+  // suites, never out of both.
+  expect(exempt).toEqual(registered);
 });

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -15,6 +15,7 @@
   "include": ["src"],
   "exclude": [
     "node_modules",
+    "src/**/*.stories.ts",
     "src/**/*.stories.tsx",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -15,6 +15,9 @@
   "include": ["src"],
   "exclude": [
     "node_modules",
+    "src/**/*.stories.js",
+    "src/**/*.stories.jsx",
+    "src/**/*.stories.mjs",
     "src/**/*.stories.ts",
     "src/**/*.stories.tsx",
     "src/**/*.test.ts",


### PR DESCRIPTION
Closes #100.

## What

The library's stories were the public demonstration surface but verified nothing:
`grep -rn 'play:' src --include='*.stories.*'` returned zero hits, and the e2e
smoke suite only asserted that each story *mounts*. This adds behavioural proof
where the behaviour is demonstrated, and a gate that cannot silently skip.

### 1. Play functions for 13 interactive components

A dedicated story per component, tagged `['interaction', '!autodocs']`, driving
the component with `userEvent` and asserting with `expect`:

| Component | Story | Asserts |
| --- | --- | --- |
| `UiButton` | `ClickInvokesHandler` | click dispatches `onClick` once |
| `UiInput` | `TypingUpdatesValue` | typed value lands; one `onChange` per keystroke |
| `UiCheckbox` | `ClickTogglesCheckedState` | click flips `checked` and reports it |
| `UiForm` | `ValidationBlocksEmptySubmit` | empty submit shows the field error and does not call `onSubmit`; a valid value does |
| `UiTextFieldForm` | `ValidationSurfacesFieldError` | validation message appears on submit and clears when the value becomes valid |
| `UiTooltip` | `ClickOpensTooltip` | closed at rest, opens on click, `aria-expanded` follows |
| `UiLink` | `KeyboardFocusExposesNewTabHint` | keyboard reachable; new-tab hint in the accessible name; `rel="noopener noreferrer"` |
| `UiBackToMain` | `KeyboardFocusReachesBackLink` | keyboard reachable link pointing at `to` |
| `UiSearchInput` | `SuggestionPickFillsField` | typing filters suggestions; picking one fills the field |
| `UiSelectWithSearch` | `SearchNarrowsAndSelectsOption` | search narrows the listbox; the pick becomes the value |
| `UiMultiSelect` | `PickingOptionsAddsChips` | two picks become two chips |
| `UiRadioGroup` | `ChoosingOptionMovesSelection` | choosing checks one and unchecks the previous |
| `UiCalendarMultiSelect` | `DayToggleUpdatesSelection` | a day toggles on and back off via `aria-selected` |

They are **new** exports, never `play` bolted onto an existing story: Storybook
autoplays `play` as soon as a canvas renders, which would destabilise the pinned
visual baseline of the story it demos. The four always-controlled field controls
get a stateful render wrapper so typing/selection actually sticks, and every
asserted handler is an explicit `fn()` spy (an implicit action arg throws when a
play function invokes it).

### 2. `make test-storybook` — fail-closed

Boots the shared Storybook service and runs `scripts/ci/run-storybook-interactions.ts`
in the Playwright image, reusing the existing `run-storybook-playwright` helper
(extended with a `PLAYWRIGHT_RUN_CMD` hook; the default path is byte-identical).

`@storybook/test-runner --includeTags interaction` rewrites every story file
without a matching story into a **skipped no-op suite**, so Jest alone exits `0`
when the tag disappears library-wide. The script therefore brackets the run:

1. **before** — the live Storybook index must expose exactly the stories
   registered in `tests/storybook/interaction-stories.json`, covering at least
   8 components;
2. **run** — `--includeTags interaction`, chromium, JUnit reporter;
3. **after** — the JUnit report must contain one *passing* `play-test` per
   registered story.

Verified failure modes (all exit `1`): empty registry, registry/index drift,
component count below the floor, any failing or skipped play test.

### 3. Coverage can only grow

- `tests/unit/storybook-interaction-coverage.test.ts` scans the story sources
  with the TypeScript AST (no module evaluation, so Stryker never re-runs it per
  mutant): a `play` function that is not tagged `interaction` **and** registered
  fails the unit suite.
- `tests/visual/visual.spec.ts` keeps its manifest-completeness gate untouched and
  adds a reciprocal one: the only stories the screenshot loop skips are the
  registered interaction stories, and every registered id is a real story.
  Interaction stories are pixel-exempt because their canvas mutates itself
  asynchronously — a screenshot races the `play` phase — and they keep their e2e
  smoke coverage on all three engines.

### 4. Contracts and docs

`tests/bats/make-target-coverage.tsv` row, two new `makefile_targets.bats` tests
(the target runs the gate, and the shared helper still defaults to Playwright for
`test-e2e`/`test-visual`), `test-storybook` added to `GATING_TARGETS`, plus
README / agents.md / CONTRIBUTING.md / `tests/storybook/README.md`.

## Incidental unblock

`main`'s Docker builds are currently broken: the pinned `nodejs=22.23.0-r0` and
`python3=3.12.13-r0` were dropped from the Alpine v3.22 index, so every
Docker-backed job fails at `apk add`. Bumped to the patch levels the index now
carries (verified with `apk add -s`). Separately, the Storybook node API eagerly
creates `node_modules/.cache/storybook`, which `pwuser` could not write — that
directory is now pre-created and chowned in `Dockerfile.playwright` (node_modules
itself stays root-owned).

## Acceptance criteria

- [x] Runner added, caret-pinned (`@storybook/test-runner@^0.24.4`). **Note:**
      `@storybook/test` tops out at 8.6.x and peers on `storybook@^8`; Storybook 10's
      equivalent is the `storybook/test` subpath of the already-installed
      `storybook@10.4.3`, which is what the play functions import.
- [x] 13 interactive components have `play` functions using `userEvent` + `expect` (≥ 8).
- [x] `make test-storybook` runs headlessly in the Docker Playwright image and exits
      non-zero on any failure or on zero tests discovered.
- [x] New workflow runs it on PRs to `main` with no conditional skip path.
- [x] Interactions appear in the Storybook Interactions panel (built into Storybook 10 core).
- [x] `tests/bats/make-target-coverage.tsv` and the Bats contract updated.

Axe / keyboard / focus-order a11y assertions stay out of scope per the issue (#66).

## Verification

Run locally against Docker on this branch:

| Check | Result |
| --- | --- |
| `make test-storybook` | 13 passed |
| `make test-e2e` | 216 passed (3 engines) |
| `make test-visual` | 71 passed, 130 skipped |
| `make lint-metrics` | all hard checks pass |
| `make lint-deps` | 0 errors |
| Bats suite | 271 passed |
| Jest unit | 624 passed, 100% coverage |
| Jest integration | 70 passed, 100% coverage |
| tsc / ESLint / Prettier / markdownlint | clean |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Storybook interaction tests (play functions) for 13 components and a fail-closed `make test-storybook` gate so browser-proven behavior cannot silently disappear. Previously stories only mounted; now each registered interaction story must run and pass in CI, and the gate fails on registry/index drift, duplicate entries, coverage below the floor, or any missing/failed/skipped play test.

- Adds `interaction`-tagged `play` stories for 13 components using `userEvent`/`expect` from `storybook/test`; controlled inputs use stateful wrappers and asserted handlers use explicit `fn()` spies. Stories are separate exports to avoid autoplay breaking visual baselines; a shared body in `.storybook/field-typeahead-interactions.ts` drives typeahead fields.
- Introduces `@storybook/test-runner` and `scripts/ci/run-storybook-interactions.ts`: reconciles the live index with `tests/storybook/interaction-stories.json`, enforces a ≥8-component floor, runs chromium only, then requires one passing play test per entry from JUnit and reports the distinct passed count. Hardening: manifest path is contained to the repo root with lexical and `realpathSync` checks, runner spawned via `process.execPath`, trailing slashes trimmed, output sanitized, duplicate rows rejected in both id and title+exportName key spaces, JUnit names XML‑decoded, explicit `localeCompare`/`String#endsWith` comparisons, and the count deduplicates repeated report rows.
- Drift guards: a static scan of CSF stories across all flavors (`*.stories.{js,jsx,mjs,ts,tsx}`) requires `play` stories to be tagged `interaction` and registered; it reads meta titles from inline defaults, resolves `export default meta` and `export { meta as default }` back to the declaration, and sees through `as`/`satisfies`. Stories are copied into the Stryker sandbox (still excluded from `mutate`). Dependency-cruiser and Jest/tsconfig exclusions now mirror the same multi-flavor patterns (including `.mjs`).
- Visual suite exempts registered interaction stories and asserts the exemption matches the registry; all registered ids remain real stories. A PR workflow runs the gate on PRs to `main` without a skip guard. Docker pins bumped for Alpine index drift and a writable `/app/node_modules/.cache` is created for the Playwright image. Docs include a one‑liner to regenerate the interaction manifest.

- Rollout
  - Add a dedicated `interaction` story export with a `play` function and register it in `tests/storybook/interaction-stories.json`; do not attach `play` to existing stories.
  - Use explicit `fn()` spies for asserted handlers.
  - Run `make test-storybook`; update the visual manifest so interaction stories stay pixel‑exempt.

<sup>Written for commit 6bca5976a14b5f99eaeb5a1ee0497e423beb91c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/ui-toolkit/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

